### PR TITLE
logname watdo -> vdirsyncer

### DIFF
--- a/vdirsyncer/log.py
+++ b/vdirsyncer/log.py
@@ -25,7 +25,7 @@ loggers = {}
 
 
 def get(name):
-    name = 'watdo.' + name
+    name = 'vdirsyncer.' + name
     if name not in loggers:
         loggers[name] = create_logger(name)
     return loggers[name]


### PR DESCRIPTION
I'm actually a fan of putting something like **programname** = 'vdirsyncer' into the topmost **init** and importing that everywhere the progamname is used. What do you think?
