### PR TITLE
Don't suggest that `name = value # A comment` is a valid definition.

### DIFF
--- a/example.cfg
+++ b/example.cfg
@@ -64,9 +64,11 @@ url = https://owncloud.example.com/remote.php/carddav/addressbooks/bob/
 # The password can also be fetched from the system password storage or netrc
 #password =
 
-#true: The NSA can spy on you with some effort
-#false: Everybody can spy on you with no effort
-#path to SSL cert: People will call you paranoid
+# SSL settings:
+#   `True` - The NSA can spy on you with some effort (use SSL)
+#   `False` - Everybody can spy on you with no effort (don't use SSL)
+#   `path/to/SSL/cert` - People will call you paranoid (if you use a self-
+#                       signed certificate you need to copy it to this machine)
 #verify = True
 
 # CALDAV


### PR DESCRIPTION
The example configuration file suggests at several places that this is a valid parameter definition:
`parameter_name = value # A comment`

This pull request fixes all of these places in the example configuration file (+ adds some explanation to the `verify` parameter).
