### PR TITLE
Preserve order of parameters and properties

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
     - "3.4"
 env:
     - BUILD=tests DAV_SERVER=radicale RADICALE_BACKEND=filesystem REQUIREMENTS=release
+    - BUILD=tests DAV_SERVER=radicale RADICALE_BACKEND=filesystem REQUIREMENTS=release PKGS='icalendar==3.6'
     - BUILD=tests DAV_SERVER=radicale RADICALE_BACKEND=filesystem REQUIREMENTS=devel
     - BUILD=tests DAV_SERVER=radicale RADICALE_BACKEND=database REQUIREMENTS=devel
     - BUILD=tests DAV_SERVER=owncloud REQUIREMENTS=release
@@ -12,5 +13,6 @@ env:
 
 install:
     - "./build.sh install"
+    - '[ -z "$PKGS" ] || pip install $PKGS'
 script:
     - "./build.sh run"


### PR DESCRIPTION
Since version 3.7, icalendar supports the preserving of the order of the ICS
file's parameters and properties. We can use this to avoid unnecessary changes
for .ics files managed with singlefilestorage.
