### PR TITLE
Make sync more performant

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -117,7 +117,8 @@ def test_simple_run(tmpdir):
     tmpdir.join('path_a/haha.txt').write('UID:haha')
     result = runner.invoke(cli.app, ['sync'])
     assert result.output == ('Syncing my_pair\n'
-                             'Copying (uploading) item haha to my_b\n')
+                             'Copying (uploading) items to my_b:\n'
+                             '    haha\n')
     assert tmpdir.join('path_b/haha.txt').read() == 'UID:haha'
 
     result = runner.invoke(cli.app, ['sync', 'my_pair', 'my_pair'])

--- a/vdirsyncer/storage/base.py
+++ b/vdirsyncer/storage/base.py
@@ -137,6 +137,15 @@ class Storage(object):
         '''
         raise NotImplementedError()
 
+    def upload_multi(self, items):
+        '''Upload multiple items.
+
+        :param items: An iterable of items objects.
+        :returns: [(href, etag)]
+        '''
+        for item in items:
+            yield self.upload(item)
+
     def update(self, href, item, etag):
         '''Update an item.
 
@@ -148,6 +157,15 @@ class Storage(object):
         '''
         raise NotImplementedError()
 
+    def update_multi(self, iterable):
+        '''Update multiple items.
+
+        :param iterable: An iterable of tuples of (href, item, etag)
+        :returns: A list of etags
+        '''
+        for href, item, etag in iterable:
+            yield self.update(href, item, etag)
+
     def delete(self, href, etag):
         '''Delete an item by href.
 
@@ -155,3 +173,11 @@ class Storage(object):
             a different etag or doesn't exist.
         '''
         raise NotImplementedError()
+
+    def delete_multi(self, iterable):
+        '''Delete multiple items by hrefs.
+
+        :param iterable: An iterable of (href, etag) tuples.
+        '''
+        for href, etag in iterable:
+            self.delete(href, etag)


### PR DESCRIPTION
- This commit rewrites the sync algorithm to use the new upload_multi, 
  update_multi and delete_multi methods for storages which support them.
- That change doesn't do anything useful for most storages, but
  singlefile-storage benefits tremendously from this.
