### PR TITLE
Split recurring events properly

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,12 @@ Package maintainers and users who have to manually update their installation
 may want to subscribe to `GitHub's tag feed
 <https://github.com/pimutils/vdirsyncer/tags.atom>`_.
 
+Version 0.9.3
+=============
+
+- :storage:`singlefile` and :storage:`http` now handle recurring events
+  properly.
+
 Version 0.9.2
 =============
 


### PR DESCRIPTION
Previously we moved each VEVENT into its own Item, now we group by UID,
if one exists.