### PR TITLE
OAuth2 (Google variant) for CalDav and CardDav

### DIFF
--- a/docs/supported.rst
+++ b/docs/supported.rst
@@ -216,13 +216,15 @@ frequently.
     type = caldav
     url = https://apidata.googleusercontent.com/caldav/v2/
     auth = oauth2_google
-    password = ~/.vdirsyncer/oauth-token
 
     [storage card]
     type = carddav
     url = https://www.googleapis.com/carddav/v1/principals/EMAIL/lists/default
     auth = oauth2_google
-    password = ~/.vdirsyncer/oauth-token
+
+At first run you will be asked to authorize application for google account
+access. Simply follow the instructions. You'll be asked to modify configuration
+file (save `refresh_token` as a password).
 
 - Google's CardDav implementation is very limited, may lead to data loss, use
   with care.

--- a/docs/supported.rst
+++ b/docs/supported.rst
@@ -207,5 +207,26 @@ Vdirsyncer is continuously tested against the latest version of Baikal_.
 Google
 ------
 
-Vdirsyncer doesn't currently support Google accounts fully. For possible
-solutions see :gh:`202` and :gh:`8`.
+Using vdirsyncer with Google Callendar is possible, but it is not tested
+frequently.
+
+::
+
+    [storage cal]
+    type = caldav
+    url = https://apidata.googleusercontent.com/caldav/v2/
+    auth = oauth2_google
+    password = ~/.vdirsyncer/oauth-token
+
+    [storage card]
+    type = carddav
+    url = https://www.googleapis.com/carddav/v1/principals/EMAIL/lists/default
+    auth = oauth2_google
+    password = ~/.vdirsyncer/oauth-token
+
+- Google's CardDav implementation is very limited, may lead to data loss, use
+  with care.
+- You can select which callendars to sync on
+  `CalDav settings page <https://calendar.google.com/calendar/syncselect>`_
+
+For more information see :gh:`202` and :gh:`8`.

--- a/docs/supported.rst
+++ b/docs/supported.rst
@@ -207,7 +207,7 @@ Vdirsyncer is continuously tested against the latest version of Baikal_.
 Google
 ------
 
-Using vdirsyncer with Google Callendar is possible, but it is not tested
+Using vdirsyncer with Google Calendar is possible, but it is not tested
 frequently.
 
 ::
@@ -226,7 +226,7 @@ frequently.
 
 - Google's CardDav implementation is very limited, may lead to data loss, use
   with care.
-- You can select which callendars to sync on
+- You can select which calendars to sync on
   `CalDav settings page <https://calendar.google.com/calendar/syncselect>`_
 
 For more information see :gh:`202` and :gh:`8`.

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,8 @@ setup(
     },
     install_requires=requirements,
     extras_require={
-        'remotestorage': ['requests-oauthlib']
+        'remotestorage': ['requests-oauthlib'],
+        'oauth2': ['requests-oauthlib'],
     },
     cmdclass={
         'minimal_requirements': PrintRequirements

--- a/vdirsyncer/storage/dav.py
+++ b/vdirsyncer/storage/dav.py
@@ -355,7 +355,7 @@ class DavSession(object):
                     token=self._token,
                     redirect_uri='urn:ietf:wg:oauth:2.0:oob',
                     scope=['https://www.googleapis.com/auth/calendar',
-                           'https://www.googleapis.com/auth/contacts'],
+                           'https://www.googleapis.com/auth/carddav'],
                     auto_refresh_url=OAUTH2_GOOGLE_REFRESH_URL,
                     auto_refresh_kwargs={
                         'client_id': oauth2_client_id,

--- a/vdirsyncer/storage/dav.py
+++ b/vdirsyncer/storage/dav.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function
-
+import click
 import datetime
 import errno
 import json
@@ -369,11 +368,14 @@ class DavSession(object):
                         # access_type and approval_prompt are Google specific
                         # extra parameters.
                         access_type="offline", approval_prompt="force")
-                    print("Please go to %s" % authorization_url)
-                    # flake8 complains about raw_input even if used
-                    # only on python2
-                    print("Paste obtained code: ", end='')
-                    code = sys.stdin.readline().strip()
+                    click.echo('Opening {} ...'.format(authorization_url))
+                    try:
+                        utils.open_graphical_browser(authorization_url)
+                    except Exception as e:
+                        dav_logger.warning(str(e))
+
+                    click.echo("Follow the instructions on the page.")
+                    code = click.prompt("Paste obtained code")
                     self._token = self._session.fetch_token(
                         OAUTH2_GOOGLE_REFRESH_URL,
                         code=code,

--- a/vdirsyncer/storage/http.py
+++ b/vdirsyncer/storage/http.py
@@ -82,7 +82,10 @@ HTTP_STORAGE_PARAMETERS = '''
         information.
     :param auth: Optional. Either ``basic``, ``digest`` or ``guess``. Default
         ``guess``. If you know yours, consider setting it explicitly for
-        performance.
+        performance. For caldav and carddav, additionaly ``oauth2_google`` is
+        supported. ``password`` setting should point a file for OAuth2 token
+        storage (directory must already exists, but file itself will be created
+        automatically).
     :param auth_cert: Optional. Either a path to a certificate with a client
         certificate and the key or a list of paths to the files with them.
     :param useragent: Default ``vdirsyncer``.


### PR DESCRIPTION
This is mostly implementation of the ideas in https://github.com/pimutils/vdirsyncer/issues/8

It adds new `auth` value of `oauth2_google`. Then reuse `password` setting for token storage path. Actual authentication code must be obtained by the user, by following printed URL and then pasting retrieved code into the console. That happens only for the first time, later stored token is used.

Open questions, todos:
 - request and fill google app token (client id, client secret)
 - add option to specify them in configuration - I don't know how to get a (global?) config value from inside of Storage object
 - write some tests? but how to do that without exposing test calendar credentials (you can't simply run local google calendar instance...)? then how to handle interactive google confirmation? 
 - interactive prompt for authentication code (only at first run) isn't nice from architectural point of view, but it's really convenient - compared to some alternatives like pasting it to some file. Any better idea?
 - reusing password for token storage path looks awful, any better idea besides creating new option and passing it down through all the code path?

I've tested it only for caldav, not carddav. And according to http://evertpot.com/google-carddav-issues/ I expect the later to fail badly.