### PR TITLE
Bugfixes for Google storage

### DIFF
--- a/vdirsyncer/storage/google.py
+++ b/vdirsyncer/storage/google.py
@@ -5,7 +5,7 @@ import logging
 
 import click
 
-from . import dav
+from . import base, dav
 from .. import exceptions, utils
 
 logger = logging.getLogger(__name__)
@@ -34,6 +34,8 @@ class GoogleSession(dav.DavSession):
 
         self.useragent = client_id
         self._settings = {}
+
+        token_file = utils.expand_path(token_file)
 
         if not have_oauth2:
             raise exceptions.UserError('requests-oauthlib not installed')
@@ -119,7 +121,7 @@ class GoogleCalendarStorage(dav.CaldavStorage):
 
     def __init__(self, token_file, client_id=None, client_secret=None,
                  start_date=None, end_date=None, item_types=(), **kwargs):
-        super(GoogleContactsStorage, self).__init__(
+        super(GoogleCalendarStorage, self).__init__(
             token_file=token_file, client_id=client_id,
             client_secret=client_secret, start_date=start_date,
             end_date=end_date, item_types=item_types,
@@ -129,7 +131,7 @@ class GoogleCalendarStorage(dav.CaldavStorage):
     # This is ugly: We define/override the entire signature computed for the
     # docs here because the current way we autogenerate those docs are too
     # simple for our advanced argspec juggling in `vdirsyncer.storage.dav`.
-    __init__._traverse_superclass = False
+    __init__._traverse_superclass = base.Storage
 
 
 class GoogleContactsStorage(dav.CarddavStorage):

--- a/vdirsyncer/utils/__init__.py
+++ b/vdirsyncer/utils/__init__.py
@@ -87,9 +87,13 @@ def get_storage_init_specs(cls, stop_at=object):
         return ()
 
     spec = getargspec_ish(cls.__init__)
-    if getattr(cls.__init__, '_traverse_superclass', True):
-        supercls = next(getattr(x.__init__, '__objclass__', x)
-                        for x in cls.__mro__[1:])
+    traverse_superclass = getattr(cls.__init__, '_traverse_superclass', True)
+    if traverse_superclass:
+        if traverse_superclass is True:  # noqa
+            supercls = next(getattr(x.__init__, '__objclass__', x)
+                            for x in cls.__mro__[1:])
+        else:
+            supercls = traverse_superclass
         superspecs = get_storage_init_specs(supercls, stop_at=stop_at)
     else:
         superspecs = ()


### PR DESCRIPTION
- the tilde wouldn't be expanded to $HOME for token_file value, causing
  a crash

- due to wrong type signatures, vdirsyncer's storage init code would
  guess that the instance_name parameter was not allowed, and that that
  lead to the crash