### PR TITLE
Fix bug in storage init errorhandler

### DIFF
--- a/vdirsyncer/utils/__init__.py
+++ b/vdirsyncer/utils/__init__.py
@@ -114,7 +114,8 @@ def get_storage_init_args(cls, stop_at=object):
     all, required = set(), set()
     for spec in get_storage_init_specs(cls, stop_at=stop_at):
         all.update(spec.args[1:])
-        required.update(spec.args[1:-len(spec.defaults or ())])
+        last = -len(spec.defaults) if spec.defaults else len(spec.args)
+        required.update(spec.args[1:last])
 
     return all, required
 


### PR DESCRIPTION
If there are no defaults, spec.args would be sliced like
`spec.args[1:0]` which always produces an empty slice.