### PR TITLE
fully resolve well-known URI

### DIFF
--- a/vdirsyncer/storage/dav.py
+++ b/vdirsyncer/storage/dav.py
@@ -124,26 +124,16 @@ class Discover(object):
         return utils.compat.urlunquote(collection)
 
     def find_dav(self):
-        uri = self._well_known_uri
-        for i in range(5):
-            try:
-                response = self.session.request(
-                    'GET', uri, allow_redirects=False,
-                    headers=self.session.get_default_headers()
-                )
-                if not response.is_redirect:
-                    return uri
-
-                uri = response.headers.get('Location', None)
-                if not uri:
-                    dav_logger.debug('Redirected without new Location')
-                    return ''
-            except (HTTPError, exceptions.Error):
-                # The user might not have well-known URLs set up and instead points
-                # vdirsyncer directly to the DAV server.
-                dav_logger.debug('Server does not support well-known URIs.')
-                return ''
-        else:
+        try:
+            response = self.session.request(
+                'GET', self._well_known_uri, allow_redirects=True,
+                headers=self.session.get_default_headers()
+            )
+            return response.url
+        except (HTTPError, exceptions.Error):
+            # The user might not have well-known URLs set up and instead points
+            # vdirsyncer directly to the DAV server.
+            dav_logger.debug('Server does not support well-known URIs.')
             return ''
 
     def find_principal(self, url=None):

--- a/vdirsyncer/storage/dav.py
+++ b/vdirsyncer/storage/dav.py
@@ -124,16 +124,26 @@ class Discover(object):
         return utils.compat.urlunquote(collection)
 
     def find_dav(self):
-        try:
-            response = self.session.request(
-                'GET', self._well_known_uri, allow_redirects=False,
-                headers=self.session.get_default_headers()
-            )
-            return response.headers.get('Location', '')
-        except (HTTPError, exceptions.Error):
-            # The user might not have well-known URLs set up and instead points
-            # vdirsyncer directly to the DAV server.
-            dav_logger.debug('Server does not support well-known URIs.')
+        uri = self._well_known_uri
+        for i in range(5):
+            try:
+                response = self.session.request(
+                    'GET', uri, allow_redirects=False,
+                    headers=self.session.get_default_headers()
+                )
+                if not response.is_redirect:
+                    return uri
+
+                uri = response.headers.get('Location', None)
+                if not uri:
+                    dav_logger.debug('Redirected without new Location')
+                    return ''
+            except (HTTPError, exceptions.Error):
+                # The user might not have well-known URLs set up and instead points
+                # vdirsyncer directly to the DAV server.
+                dav_logger.debug('Server does not support well-known URIs.')
+                return ''
+        else:
             return ''
 
     def find_principal(self, url=None):


### PR DESCRIPTION
Currently, `find_dav` only resolves a single redirect. When using Baïkal behind a proxy with HTTPS, this becomes an issue:

1. dav.example.com/.well-known/caldav (Apache rewrite to http)
2. dav.example.com/dav.php (http)
3. dav.example.com/dav.php (https)

The Apache configuration is provided by Baïkal, hence it is also possible to fix it server-side:

  -RewriteRule /.well-known/carddav /dav.php [R,L]
  +RewriteRule /.well-known/carddav https://dav.example.com/dav.php [R,L]
  -RewriteRule /.well-known/caldav /dav.php [R,L]
  +RewriteRule /.well-known/caldav https://dav.example.com/dav.php [R,L]

This commit follows the well-known URI up to 5 times and returns the (hopefully) correctly resolved url.