### PR TITLE
DAV: Don't violate Storage API

### DIFF
--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -422,8 +422,8 @@ class SyncMachine(RuleBasedStateMachine):
         if null_etag_on_upload:
             _old_upload = s.upload
             _old_update = s.update
-            s.upload = lambda item: (_old_upload(item)[0], None)
-            s.update = lambda h, i, e: _old_update(h, i, e) and None
+            s.upload = lambda item: (_old_upload(item)[0], 'NULL')
+            s.update = lambda h, i, e: _old_update(h, i, e) and 'NULL'
 
         return s
 

--- a/vdirsyncer/storage/dav.py
+++ b/vdirsyncer/storage/dav.py
@@ -479,10 +479,9 @@ class DavStorage(Storage):
         #
         # -- https://tools.ietf.org/html/rfc7231#section-4.3.4
         #
-        # In such cases we return None as etag. The next synchronization will
-        # then detect an etag change (None != some string) and will download
-        # the new item.
-        etag = response.headers.get('etag', None)
+        # In such cases we return a constant etag. The next synchronization
+        # will then detect an etag change and will download the new item.
+        etag = response.headers.get('etag', 'NULL')
         href = self._normalize_href(response.url)
         return href, etag
 


### PR DESCRIPTION
The implementation of #476 is problematic as it returns None.
`vdirsyncer.sync` has internal assertions that this is a string, which
is why we get a crash like this:

    error: Unknown error occured for cal/markus@unterwaditzer.net:
    error: Use `-vdebug` to see the full traceback.
    debug:   File "/home/untitaker/projects/vdirsyncer/vdirsyncer/cli/tasks.py", line 66, in sync_collection
    debug:     force_delete=force_delete
    debug:   File "/home/untitaker/projects/vdirsyncer/vdirsyncer/sync.py", line 228, in sync
    debug:     action(a_info, b_info, conflict_resolution)
    debug:   File "/home/untitaker/projects/vdirsyncer/vdirsyncer/sync.py", line 276, in inner
    debug:     assert isinstance(dest_etag, (bytes, text_type))

Discovered in #467