### PR TITLE
Refactor of status handling in sync

### DIFF
--- a/vdirsyncer/storage/base.py
+++ b/vdirsyncer/storage/base.py
@@ -3,7 +3,7 @@
 import contextlib
 import functools
 
-from .. import exceptions, sync
+from .. import exceptions
 from ..utils import uniq
 from ..utils.vobject import Item  # noqa
 
@@ -46,8 +46,6 @@ class Storage(metaclass=StorageMeta):
     '''
 
     fileext = '.txt'
-
-    syncer_class = sync.StorageSyncer
 
     # The string used in the config to denote the type of storage. Should be
     # overridden by subclasses.


### PR DESCRIPTION
- Using `info.idents` as new status, this saves a few operations where
  no storage actions have to be taken, but the status has to be updated.

- Rename StorageSyncer to _StorageInfo and make it a private API again.

- Ability to pass custom functions for conflict resolution. This part is
  a preparation for #127.