### PR TITLE
Strip trailing slash from .well-known-URIs to fix autodiscovery

### DIFF
--- a/vdirsyncer/storage/dav.py
+++ b/vdirsyncer/storage/dav.py
@@ -281,7 +281,7 @@ class CalDiscover(Discover):
     </d:propfind>
     """
     _homeset_tag = '{%s}calendar-home-set' % _namespace
-    _well_known_uri = '/.well-known/caldav/'
+    _well_known_uri = '/.well-known/caldav'
 
 
 class CardDiscover(Discover):
@@ -295,7 +295,7 @@ class CardDiscover(Discover):
     </d:propfind>
     """
     _homeset_tag = '{%s}addressbook-home-set' % _namespace
-    _well_known_uri = '/.well-known/carddav/'
+    _well_known_uri = '/.well-known/carddav'
 
 
 class DavSession(object):

--- a/vdirsyncer/storage/google.py
+++ b/vdirsyncer/storage/google.py
@@ -154,7 +154,7 @@ class GoogleContactsStorage(dav.CarddavStorage):
     class session_class(GoogleSession):
         # Apparently Google wants us to submit a PROPFIND to the well-known
         # URL, instead of looking for a redirect.
-        url = 'https://www.googleapis.com/.well-known/carddav/'
+        url = 'https://www.googleapis.com/.well-known/carddav'
         scope = ['https://www.googleapis.com/auth/carddav']
 
     storage_name = 'google_contacts'


### PR DESCRIPTION
According to RFC6764 URLs should be "/.well-known/caldav" and
"/.well-known/caldav".

Tested with Baïkal, but redirect for .well-known-URIs defined in nginx config so it is not Baïkal-specific.

May be `https://www.googleapis.com/.well-known/carddav/` should also be changed to `https://www.googleapis.com/.well-known/carddav`. See: https://developers.google.com/google-apps/carddav/ But I don't use vdirsyncer with google and can't test this change.