### PR TITLE
Fix spelling error in docs

### DIFF
--- a/docs/when.rst
+++ b/docs/when.rst
@@ -42,7 +42,7 @@ program chosen:
   
   This is a good idea if the user is directly interfacing with the file system
   and is able to resolve conflicts themselves.  Here it might lead to
-  errorneous behavior with e.g. ``khal``, since there are now two events with
+  erroneous behavior with e.g. ``khal``, since there are now two events with
   the same UID.
 
   This point doesn't apply to git: It has very good merging capabilities,


### PR DESCRIPTION
Resulting in lintian complain:
I: vdirsyncer: spelling-error-in-manpage usr/share/man/man1/vdirsyncer.1.gz errorneous erroneous