### PR TITLE
Return back to None as non-ETag

### DIFF
--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -500,6 +500,20 @@ class SyncMachine(RuleBasedStateMachine):
         s.update = action_failure
         s.delete = action_failure
 
+    @rule(s=Storage)
+    def none_as_etag(self, s):
+        _old_upload = s.upload
+        _old_update = s.update
+
+        def upload(item):
+            return _old_upload(item)[0], None
+
+        def update(href, item, etag):
+            _old_update(href, item, etag)
+
+        s.upload = upload
+        s.update = update
+
     @rule(target=Status)
     def newstatus(self):
         return {}

--- a/vdirsyncer/storage/base.py
+++ b/vdirsyncer/storage/base.py
@@ -166,6 +166,10 @@ class Storage(metaclass=StorageMeta):
     def upload(self, item):
         '''Upload a new item.
 
+        In cases where the new etag is not known, this method may return `None`
+        as etag. This special case only exists because of DAV. Avoid this
+        situation whenever possible.
+
         :raises: :exc:`vdirsyncer.exceptions.PreconditionFailed` if there is
             already an item with that href.
 
@@ -175,6 +179,10 @@ class Storage(metaclass=StorageMeta):
 
     def update(self, href, item, etag):
         '''Update an item.
+
+        In cases where the new etag is not known, this method may return `None`
+        as etag. This special case only exists because of DAV. Avoid this
+        situation whenever possible.
 
         :raises: :exc:`vdirsyncer.exceptions.PreconditionFailed` if the etag on
             the server doesn't match the given etag or if the item doesn't

--- a/vdirsyncer/storage/dav.py
+++ b/vdirsyncer/storage/dav.py
@@ -509,7 +509,7 @@ class DAVStorage(Storage):
         #
         # In such cases we return a constant etag. The next synchronization
         # will then detect an etag change and will download the new item.
-        etag = response.headers.get('etag', 'NULL')
+        etag = response.headers.get('etag', None)
         href = self._normalize_href(response.url)
         return href, etag
 

--- a/vdirsyncer/sync.py
+++ b/vdirsyncer/sync.py
@@ -354,7 +354,6 @@ class Update(Action):
             meta = self.dest.new_status[self.ident]
             meta.etag = \
                 self.dest.storage.update(meta.href, self.item, meta.etag)
-            assert isinstance(meta.etag, (bytes, str))
 
         self.dest.new_status[self.ident] = meta
 


### PR DESCRIPTION
nextCloud now returns no etag on upload, which is why we're forced to
adapt the tests accordingly. So now we need to specify a fixed value for
"no etag returned" such that the tests can act accordingly. We also need
to test that the sync algorithm works properly with None.