### PR TITLE
Shell-expand user home directory in confres command

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -11,5 +11,6 @@ In alphabetical order:
 - Malte Kiefer
 - Marek Marczykowski-Górecki
 - Markus Unterwaditzer
+- Martin Krafft
 - Michael Adler
 - Thomas Weißschuh

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,9 @@ Version 0.15
 - Deprecated syntax for configuration values is now completely rejected. All
   values now have to be valid JSON.
 - A few UX improvements for Google storages, see :gh:`549` and :gh:`552`.
+- Conflict resolution commands now get path-expanded, i.e. "~/bin/myresolver"
+  is now acceptable, whereas before one had to specify the absolute path
+  including the home directory, see :gh:`563`.
 
 Version 0.14.1
 ==============

--- a/vdirsyncer/cli/config.py
+++ b/vdirsyncer/cli/config.py
@@ -246,6 +246,8 @@ class PairConfig(object):
             def resolve(a, b):
                 a_name = self.config_a['instance_name']
                 b_name = self.config_b['instance_name']
+                conflict_resolution[1] = \
+                        os.path.expanduser(conflict_resolution[1])
                 command = conflict_resolution[1:]
 
                 def inner():


### PR DESCRIPTION
Let me specify the command to use for conflict resolution with `~` in the path, which gets expanded to my homedir.

Signed-off-by: martin f. krafft <madduck@madduck.net>