### PR TITLE
config.example: Status path needs to be quoted

### DIFF
--- a/config.example
+++ b/config.example
@@ -9,7 +9,7 @@
 
 [general]
 # A folder where vdirsyncer can store some metadata about each pair.
-status_path = ~/.vdirsyncer/status/
+status_path = "~/.vdirsyncer/status/"
 
 # CARDDAV
 [pair bob_contacts]


### PR DESCRIPTION
Seems like this one is missing quotation (and I was unable to get vdirsyncer working without it).