### PR TITLE
Fixed some typos.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -64,7 +64,7 @@ Version 0.13.0
 - Config sections are now checked for duplicate names. This also means that you
   cannot have a storage section ``[storage foo]`` and a pair ``[pair foo]`` in
   your config, they have to have different names. This is done such that
-  console output is always unambigous. See :gh:`459`.
+  console output is always unambiguous. See :gh:`459`.
 - Custom commands can now be used for conflict resolution during sync. See
   :gh:`127`.
 - :storage:`http` now completely ignores UIDs. This avoids a lot of unnecessary
@@ -134,7 +134,7 @@ Version 0.11.0
   - The ``keyring`` fetching strategy has been dropped some versions ago, but
     the specialized error message has been dropped.
 
-  - A old status format from version 0.4 is no longer supported. If you're
+  - An old status format from version 0.4 is no longer supported. If you're
     experiencing problems, just delete your status folder.
 
 Version 0.10.0
@@ -233,7 +233,7 @@ Version 0.7.4
 - Improved error messages instead of faulty server behavior, see :gh:`290` and
   :gh:`300`.
 - Safer shutdown of threadpool, avoid exceptions, see :gh:`291`.
-- Fix a sync bug for read-only storages see commmit
+- Fix a sync bug for read-only storages see commit
   ``ed22764921b2e5bf6a934cf14aa9c5fede804d8e``.
 - Etag changes are no longer sufficient to trigger sync operations. An actual
   content change is also necessary. See :gh:`257`.

--- a/docs/ssl-tutorial.rst
+++ b/docs/ssl-tutorial.rst
@@ -25,7 +25,7 @@ You can use the following command for obtaining a SHA-1 fingerprint::
     echo -n | openssl s_client -connect unterwaditzer.net:443 | openssl x509 -noout -fingerprint
 
 Note that ``verify_fingerprint`` doesn't suffice for vdirsyncer to work with
-self-signed certifcates (or certificates that are not in your trust store). You
+self-signed certificates (or certificates that are not in your trust store). You
 most likely need to set ``verify = false`` as well. This disables verification
 of the SSL certificate's expiration time and the existence of it in your trust
 store, all that's verified now is the fingerprint.

--- a/docs/tutorials/claws-mail.rst
+++ b/docs/tutorials/claws-mail.rst
@@ -72,7 +72,7 @@ Open Claws-Mail. Got to **Tools** => **Addressbook**.
 Click on **Addressbook** => **New vCard**. Choose a name for the book.
 
 Then search for the for the vCard in the folder **~/.contacts/**. Click
-ok, and you we will see your conatcts.
+ok, and you we will see your contacts.
 
 .. note::
     

--- a/vdirsyncer/storage/base.py
+++ b/vdirsyncer/storage/base.py
@@ -33,7 +33,7 @@ class Storage(metaclass=StorageMeta):
           contact.
       - HREF: String; Per-storage identifier of item, might be UID. The reason
           items aren't just referenced by their UID is because the CalDAV and
-          CardDAV specifications make this imperformant to implement.
+          CardDAV specifications make this unperformant to implement.
       - ETAG: String; Checksum of item, or something similar that changes when
           the item does.
 

--- a/vdirsyncer/sync.py
+++ b/vdirsyncer/sync.py
@@ -217,7 +217,7 @@ def sync(storage_a, storage_b, status, conflict_resolution=None,
     :param conflict_resolution: A function that, given two conflicting item
         versions A and B, returns a new item with conflicts resolved. The UID
         must be the same. The strings `"a wins"` and `"b wins"` are also
-        accepted to mean that that side's version will always be taken. If none
+        accepted to mean that side's version will always be taken. If none
         is provided, the sync function will raise :py:exc:`SyncConflict`.
     :param force_delete: When one storage got completely emptied between two
         syncs, :py:exc:`StorageEmpty` is raised for

--- a/vdirsyncer/vobject.py
+++ b/vdirsyncer/vobject.py
@@ -90,7 +90,7 @@ class Item(object):
 
         # We hash the item instead of directly using its raw content, because
         #
-        # 1. The raw content might be really large, e.g. when its a contact
+        # 1. The raw content might be really large, e.g. when it's a contact
         #    with a picture, which bloats the status file.
         #
         # 2. The status file would contain really sensitive information.


### PR DESCRIPTION
I installed mwic, so you don't have to.

`unperformant` doesn't seem to be an often used english word either and
`addressbook` is probably `address book`.