### PR TITLE
Add quotes to the suggested config

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -41,7 +41,7 @@ where the only required parameter is ``status_path``. The following is a
 minimal example::
 
     [general]
-    status_path = ~/.vdirsyncer/status/
+    status_path = "~/.vdirsyncer/status/"
 
 After the general section, an arbitrary amount of *pair and storage sections*
 might come.


### PR DESCRIPTION
Without the quotes the app doesn't start, throwing: 

```
critical: Error during reading config /home/kuba/.vdirsyncer/config: Section "general": Section "general", option "status_path": Expecting value: line 1 column 1 (char 0)
```