### PR TITLE
Abstract status into own class

### DIFF
--- a/vdirsyncer/sync.py
+++ b/vdirsyncer/sync.py
@@ -313,7 +313,6 @@ class _StorageInfo(object):
         return self._item_cache[ident]
 
 
-
 def _migrate_status(status):
     for ident in list(status):
         value = status[ident]

--- a/vdirsyncer/sync.py
+++ b/vdirsyncer/sync.py
@@ -99,7 +99,7 @@ class _IdentAlreadyExists(SyncError):
                              hrefs=[self.old_href, self.new_href])
 
 
-class _Status(object):
+class _SubStatus(object):
     def __init__(self, ident_to_props=None):
         self._ident_to_props = ident_to_props or {}
         self._new_ident_to_props = {}
@@ -181,11 +181,10 @@ class _StorageInfo(object):
         self.storage = storage
 
         #: Represents the status as given. Must not be modified.
-        self.status = _Status(status)
+        self.status = _SubStatus(status)
 
     def prepare_new_status(self):
         prefetch = []
-        self.new_status = _Status()
 
         def _store_props(ident, props):
             try:


### PR DESCRIPTION
This is in preparation for #546. Instead of using a dictionary, we define a class that exposes a limited interface to that dictionary. Instead of copying the dictionary into a different format, we define a proxy class.