### PR TITLE
Use sqlite for sync internally

### DIFF
--- a/tests/unit/test_sync.py
+++ b/tests/unit/test_sync.py
@@ -390,6 +390,7 @@ def test_partial_sync_revert():
     a.items[next(iter(a.items))] = ('foo', Item('UID:2\nupdated'))
     assert items(a) == {'UID:2\nupdated'}
     sync(a, b, status, partial_sync='revert')
+    assert len(status) == 1
     assert items(a) == {'UID:2\nupdated'}
     sync(a, b, status, partial_sync='revert')
     assert items(a) == {'UID:2'}

--- a/tests/unit/test_sync.py
+++ b/tests/unit/test_sync.py
@@ -184,7 +184,7 @@ def test_deletion():
     assert items(a) == items(b) == {item2.raw}
 
 
-def test_insert_hash():
+def test_broken_status():
     a = MemoryStorage()
     b = MemoryStorage()
     status = {}
@@ -197,8 +197,8 @@ def test_insert_hash():
         del d['hash']
 
     a.update(href, Item('UID:1\nHAHA:YES'), etag)
-    sync(a, b, status)
-    assert 'hash' in status['1'][0] and 'hash' in status['1'][1]
+    with pytest.raises(SyncConflict):
+        sync(a, b, status)
 
 
 def test_already_synced():

--- a/vdirsyncer/sync.py
+++ b/vdirsyncer/sync.py
@@ -304,7 +304,7 @@ class _SqliteStatus(_StatusBase):
         if res is None:
             return None
 
-        if res['hash'] is None:
+        if res['hash'] is None:  # FIXME: Implement as constraint in db
             assert res['href'] is None
             assert res['etag'] is None
             return None

--- a/vdirsyncer/sync.py
+++ b/vdirsyncer/sync.py
@@ -358,10 +358,12 @@ class _SqliteStatus(_StatusBase):
         )
 
     def get_by_href_a(self, *a, **kw):
-        return self._get_by_href_impl(*a, **kw, side='a')
+        kw['side'] = 'a'
+        return self._get_by_href_impl(*a, **kw)
 
     def get_by_href_b(self, *a, **kw):
-        return self._get_by_href_impl(*a, **kw, side='b')
+        kw['side'] = 'b'
+        return self._get_by_href_impl(*a, **kw)
 
 
 class _Status(_StatusBase):

--- a/vdirsyncer/sync.py
+++ b/vdirsyncer/sync.py
@@ -176,9 +176,8 @@ class _SqliteStatus(_StatusBase):
         if self._is_latest_version():
             return
 
-        self._conn.execute('DROP TABLE IF EXISTS status')
-        self._conn.execute('DROP TABLE IF EXISTS new_status')
-        self._conn.execute('DROP TABLE IF EXISTS meta')
+        # If we ever bump the schema version, we will need a way to migrate
+        # data.
 
         self._conn.execute('''CREATE TABLE meta (
             "version" INTEGER PRIMARY KEY

--- a/vdirsyncer/sync.py
+++ b/vdirsyncer/sync.py
@@ -170,7 +170,9 @@ class _SqliteStatus(_StatusBase):
         self._path = path
         self._c = sqlite3.connect(path)
         self._c.row_factory = sqlite3.Row
+        self._update_schema()
 
+    def _update_schema(self):
         if self._is_latest_version():
             return
 
@@ -413,10 +415,10 @@ class _Status(_StatusBase):
     def transaction(self):
         with self._db.transaction():
             for ident, (a, b) in self._ident_to_props.items():
+                if a.get('hash') is None or b.get('hash') is None:
+                    continue
                 params = (ident, a.get('href'), a.get('hash'), a.get('etag'),
                           b.get('href'), b.get('hash'), b.get('etag'))
-                if None in params:
-                    continue
 
                 self._db._c.execute(
                     'INSERT INTO status'

--- a/vdirsyncer/sync.py
+++ b/vdirsyncer/sync.py
@@ -509,6 +509,7 @@ class _StorageInfo(object):
                 # In both cases we should prefetch
                 prefetch.append(href)
             else:
+                # Metadata is completely identical
                 _store_props(ident, meta)
 
         # Prefetch items

--- a/vdirsyncer/sync.py
+++ b/vdirsyncer/sync.py
@@ -524,20 +524,17 @@ class _StorageInfo(object):
         return storage_nonempty
 
     def is_changed(self, ident):
-        status = self.status.get(ident)
-        if status is None:  # new item
+        old_meta = self.status.get(ident)
+        if old_meta is None:  # new item
             return True
 
-        meta = self.status.get_new(ident)
+        new_meta = self.status.get_new(ident)
 
-        if meta.etag != status.etag:  # etag changed
-            old_hash = status.hash
-            if old_hash is None or meta.hash != old_hash:
-                # item actually changed
-                return True
-            else:
-                # only etag changed
-                return False
+        return (
+            new_meta.etag != old_meta.etag and  # etag changed
+            # item actually changed
+            (old_meta.hash is None or new_meta.hash != old_meta.hash)
+        )
 
     def set_item_cache(self, ident, item):
         actual_hash = self.status.get_new(ident).hash

--- a/vdirsyncer/sync.py
+++ b/vdirsyncer/sync.py
@@ -239,37 +239,32 @@ class _SqliteStatus(_StatusBase):
             finally:
                 self._c.execute('DELETE FROM new_status')
 
-    def insert_ident_a(self, ident, props):
+    def insert_ident_a(self, ident, a_props):
         # FIXME: Super inefficient
         old_props = self.get_new_a(ident)
         if old_props is not None:
             raise _IdentAlreadyExists(old_href=old_props.href,
-                                      new_href=props.href)
-
+                                      new_href=a_props.href)
+        b_props = self.get_new_b(ident) or _ItemMetadata()
         self._c.execute(
-            'WITH new (ident, href_a, hash_a, etag_a) '
-            '  AS ( VALUES(?, ?, ?, ?) )'
             'INSERT OR REPLACE INTO new_status '
-            'SELECT new.ident, new.href_a, old.href_b, new.hash_a, old.hash_b,'
-            '  new.etag_a, old.etag_b '
-            'FROM new LEFT JOIN new_status AS old ON old.ident = new.ident',
-            (ident, props.href, props.hash, props.etag)
+            'VALUES(?, ?, ?, ?, ?, ?, ?)',
+            (ident, a_props.href, b_props.href, a_props.hash, b_props.hash,
+             a_props.etag, b_props.etag)
         )
 
-    def insert_ident_b(self, ident, props):
+    def insert_ident_b(self, ident, b_props):
         # FIXME: Super inefficient
         old_props = self.get_new_b(ident)
         if old_props is not None:
             raise _IdentAlreadyExists(old_href=old_props.href,
-                                      new_href=props.href)
+                                      new_href=b_props.href)
+        a_props = self.get_new_a(ident) or _ItemMetadata()
         self._c.execute(
-            'WITH new (ident, href_b, hash_b, etag_b) '
-            '  AS ( VALUES(?, ?, ?, ?) )'
             'INSERT OR REPLACE INTO new_status '
-            'SELECT new.ident, old.href_a, new.href_b, old.hash_a, new.hash_b,'
-            '  old.etag_a, new.etag_b '
-            'FROM new LEFT JOIN new_status AS old ON old.ident = new.ident',
-            (ident, props.href, props.hash, props.etag)
+            'VALUES(?, ?, ?, ?, ?, ?, ?)',
+            (ident, a_props.href, b_props.href, a_props.hash, b_props.hash,
+             a_props.etag, b_props.etag)
         )
 
     def update_ident_a(self, ident, props):

--- a/vdirsyncer/sync.py
+++ b/vdirsyncer/sync.py
@@ -301,8 +301,14 @@ class _SqliteStatus(_StatusBase):
                               'FROM {table} WHERE ident=?'
                               .format(side=side, table=table),
                               (ident,)).fetchone()
-        if res is None or res['hash'] is None:
+        if res is None:
             return None
+
+        if res['hash'] is None:
+            assert res['href'] is None
+            assert res['etag'] is None
+            return None
+
         res = dict(res)
         return _ItemMetadata(**res)
 

--- a/vdirsyncer/sync.py
+++ b/vdirsyncer/sync.py
@@ -224,10 +224,14 @@ class _SqliteStatus(_StatusBase):
     def transaction(self):
         assert self._c is None
         self._c = self._conn
-        yield
-        self._c.execute('DELETE FROM status')
-        self._c.execute('INSERT INTO status '
-                        'SELECT * FROM new_status')
+        try:
+            with self._c:
+                yield
+                self._c.execute('INSERT INTO status '
+                                'SELECT * FROM new_status')
+        finally:
+            self._c.execute('DELETE FROM status')
+            self._c = None
 
     def insert_ident_a(self, ident, props):
         # FIXME: Super inefficient

--- a/vdirsyncer/sync.py
+++ b/vdirsyncer/sync.py
@@ -695,14 +695,14 @@ class Update(Action):
         self.dest = dest
 
     def _run_impl(self, a, b):
-        meta = self.dest.status.get_new(self.ident)
         if self.dest.storage.read_only:
-            meta.etag = None
+            meta = _ItemMetadata(hash=self.item.hash)
         else:
             sync_logger.info(u'Copying (updating) item {} to {}'
                              .format(self.ident, self.dest.storage))
-            meta.etag = self.dest.storage.update(meta.href, self.item,
-                                                 meta.etag)
+            meta = self.dest.status.get_new(self.ident)
+            meta.etag = \
+                self.dest.storage.update(meta.href, self.item, meta.etag)
 
         self.dest.status.update_ident(self.ident, meta)
 


### PR DESCRIPTION
Another preparation for #546

This loads the legacy JSON format into a in-memory sqlite db, does some
operations there and converts it back into JSON at the end. That's not the end
goal, but makes testing easier since we don't have to modify any tests. Later
we can then modify `sync` to finally accept a sqlite db object and do the
necessary modifications in `vdirsyncer.cli`.

Right now there are two correctness bugs left though.