### PR TITLE
Add 'netrc' strategy for keyring.

### DIFF
--- a/docs/keyring.rst
+++ b/docs/keyring.rst
@@ -38,6 +38,23 @@ You can fetch the username as well::
 
 Or really any kind of parameter in a storage section.
 
+Accessing your netrc file
+-------------------------
+
+As shown above, you can use the ``command`` strategy to fetch your credentials
+from arbitrary sources. A very common usecase is to fetch your password from
+your ``~/.netrc`` file.
+
+the netrc_ Python module enables you to fetch passwords and logins from your
+``~/.netrc`` file.
+
+Basic usage::
+
+    username.fetch = ["netrc", "login", "example.com"]
+    password.fetch = ["netrc", "password", "example.com"]
+
+.. _netrc: https://docs.python.org/3/library/netrc.html
+
 Accessing the system keyring
 ----------------------------
 

--- a/vdirsyncer/cli/fetchparams.py
+++ b/vdirsyncer/cli/fetchparams.py
@@ -85,6 +85,16 @@ def _strategy_command(*command):
                                    .format(' '.join(command), str(e)))
 
 
+def _strategy_netrc(*params):
+    import netrc
+    netrcfile = netrc.netrc()
+    netrc_params = params
+    if netrc_params[0] == "login":
+        return netrcfile.authenticators(netrc_params[1])[0]
+    elif netrc_params[0] == "password":
+        return netrcfile.authenticators(netrc_params[1])[2]
+
+
 def _strategy_prompt(text):
     return click.prompt(text, hide_input=True)
 
@@ -92,4 +102,5 @@ def _strategy_prompt(text):
 STRATEGIES = {
     'command': _strategy_command,
     'prompt': _strategy_prompt,
+    'netrc': _strategy_netrc
 }


### PR DESCRIPTION
Hi, I read [here](https://vdirsyncer.readthedocs.org/en/latest/keyring.html) that vdirsyncer enables to write username and password in a different file and use a dedicated script to fetch them. I must say I find it a little clunky.. Wouldn't it be much more elegant to use the `~/.netrc`?