### PR TITLE
Add double quote in exemple config files

### DIFF
--- a/docs/partial-sync.rst
+++ b/docs/partial-sync.rst
@@ -32,15 +32,15 @@ Paste this into your vdirsyncer config::
     [storage holidays_public]
     type = "http"
     # The URL to your iCalendar file.
-    url = ...
+    url = "..."
 
     [storage holidays_private]
     type = "caldav"
     # The direct URL to your calendar.
-    url = ...
+    url = "..."
     # The credentials to your CalDAV server
-    username = ...
-    password = ...
+    username = "..."
+    password = "..."
 
 Then run ``vdirsyncer discover holidays`` and ``vdirsyncer sync holidays``, and
 your previously created calendar should be filled with events.

--- a/docs/tutorials/davmail.rst
+++ b/docs/tutorials/davmail.rst
@@ -17,7 +17,7 @@ Exchange server you might get confronted with weird errors of all sorts
     type = "caldav"
     url = "http://localhost:1080/users/user@example.com/calendar/"
     username = "user@example.com"
-    password = ...
+    password = "..."
 
 - Older versions of DavMail handle URLs case-insensitively. See :gh:`144`.
 - DavMail is handling malformed data on the Exchange server very poorly. In

--- a/docs/tutorials/fastmail.rst
+++ b/docs/tutorials/fastmail.rst
@@ -11,13 +11,13 @@ the settings to use::
     [storage cal]
     type = "caldav"
     url = "https://caldav.messagingengine.com/"
-    username = ...
-    password = ...
+    username = "..."
+    password = "..."
 
     [storage card]
     type = "carddav"
     url = "https://carddav.messagingengine.com/"
-    username = ...
-    password = ...
+    username = "..."
+    password = "..."
 
 .. _FastMail: https://www.fastmail.com/

--- a/docs/tutorials/icloud.rst
+++ b/docs/tutorials/icloud.rst
@@ -11,14 +11,14 @@ Vdirsyncer is regularly tested against iCloud_.
     [storage cal]
     type = "caldav"
     url = "https://caldav.icloud.com/"
-    username = ...
-    password = ...
+    username = "..."
+    password = "..."
 
     [storage card]
     type = "carddav"
     url = "https://contacts.icloud.com/"
-    username = ...
-    password = ...
+    username = "..."
+    password = "..."
 
 Problems:
 

--- a/docs/tutorials/nextcloud.rst
+++ b/docs/tutorials/nextcloud.rst
@@ -7,8 +7,8 @@ Vdirsyncer is continuously tested against the latest version of NextCloud_::
     [storage cal]
     type = "caldav"
     url = "https://nextcloud.example.com/"
-    username = ...
-    password = ...
+    username = "..."
+    password = "..."
 
     [storage card]
     type = "carddav"

--- a/docs/tutorials/todoman.rst
+++ b/docs/tutorials/todoman.rst
@@ -37,8 +37,8 @@ Assuming a config like this::
     [storage calendars_dav]
     type = "caldav"
     url = "https://nextcloud.example.net/"
-    username = ...
-    password = ...
+    username = "..."
+    password = "..."
 
 ``vdirsyncer sync`` will then synchronize the calendars of your NextCloud_
 instance to subfolders of ``~/.calendar/``.

--- a/docs/tutorials/xandikos.rst
+++ b/docs/tutorials/xandikos.rst
@@ -11,13 +11,13 @@ point vdirsyncer against the root of Xandikos like this::
     [storage cal]
     type = "caldav"
     url = "https://xandikos.example.com/"
-    username = ...
-    password = ...
+    username = "..."
+    password = "..."
 
     [storage card]
     type = "carddav"
     url = "https://xandikos.example.com/"
-    username = ...
-    password = ...
+    username = "..."
+    password = "..."
 
 .. _Xandikos: https://github.com/jelmer/xandikos


### PR DESCRIPTION
Add double quote to not forget them, and avoid the message :

> `warning:` Soon, all strings have to be in double quotes. Please replace UserName with "UserName"