### PR TITLE
Update claws-mail.rst

### DIFF
--- a/docs/tutorials/claws-mail.rst
+++ b/docs/tutorials/claws-mail.rst
@@ -52,7 +52,7 @@ this:
   setup. We also set the storage to read-only such that no changes get
   synchronized back. Claws-Mail should not be able to do any changes anyway,
   but this is one extra safety step in case files get corrupted or vdirsyncer
-  behaves eratically. You can leave that part out if you want to be able to
+  behaves erratically. You can leave that part out if you want to be able to
   edit those files locally.
 - In the last section we configure that online contacts win in a conflict
   situation. Configure this part however you like. A correct value depends on
@@ -69,7 +69,7 @@ Now we discover and sync our contacts::
 Claws Mail
 ----------
 
-Open Claws-Mail. Got to **Tools** => **Addressbook**.
+Open Claws-Mail. Go to **Tools** => **Addressbook**.
 
 Click on **Addressbook** => **New vCard**. Choose a name for the book.
 


### PR DESCRIPTION
Fixed some (2) minor typos.
Actually, all I wanted to do is to fix typo "contab -e" -> "crontab -e" of page "https://vdirsyncer.pimutils.org/en/stable/tutorials/claws-mail.html", but seems already correct on github...