### PR TITLE
Support Python 3.7 and 3.8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,3 +14,12 @@ repos:
     hooks:
       - id: flake8
         additional_dependencies: [flake8-import-order, flake8-bugbear]
+  - repo: local
+    hooks:
+      - id: update-travis
+        name: Update travis job definition
+        description: Ensures that travis job definition are up to date.
+        entry: scripts/make_travisconf.py
+        files: '.*travis.*'
+        stages: [commit]
+        language: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@
     ]
   },
   "cache": "pip",
-  "dist": "trusty",
+  "dist": "bionic",
   "git": {
     "submodules": false
   },
@@ -26,10 +26,12 @@
         "python": "3.5"
       },
       {
+        "dist": "trusty",
         "env": "BUILD=test-storage DAV_SERVER=radicale REQUIREMENTS=release ",
         "python": "3.5"
       },
       {
+        "dist": "trusty",
         "env": "BUILD=test-storage DAV_SERVER=xandikos REQUIREMENTS=release ",
         "python": "3.5"
       },
@@ -38,10 +40,12 @@
         "python": "3.5"
       },
       {
+        "dist": "trusty",
         "env": "BUILD=test-storage DAV_SERVER=radicale REQUIREMENTS=minimal ",
         "python": "3.5"
       },
       {
+        "dist": "trusty",
         "env": "BUILD=test-storage DAV_SERVER=xandikos REQUIREMENTS=minimal ",
         "python": "3.5"
       },
@@ -73,6 +77,54 @@
       {
         "env": "BUILD=test-storage DAV_SERVER=xandikos REQUIREMENTS=minimal ",
         "python": "3.6"
+      },
+      {
+        "env": "BUILD=test REQUIREMENTS=release",
+        "python": "3.7"
+      },
+      {
+        "env": "BUILD=test-storage DAV_SERVER=radicale REQUIREMENTS=release ",
+        "python": "3.7"
+      },
+      {
+        "env": "BUILD=test-storage DAV_SERVER=xandikos REQUIREMENTS=release ",
+        "python": "3.7"
+      },
+      {
+        "env": "BUILD=test REQUIREMENTS=minimal",
+        "python": "3.7"
+      },
+      {
+        "env": "BUILD=test-storage DAV_SERVER=radicale REQUIREMENTS=minimal ",
+        "python": "3.7"
+      },
+      {
+        "env": "BUILD=test-storage DAV_SERVER=xandikos REQUIREMENTS=minimal ",
+        "python": "3.7"
+      },
+      {
+        "env": "BUILD=test REQUIREMENTS=release",
+        "python": "3.8"
+      },
+      {
+        "env": "BUILD=test-storage DAV_SERVER=radicale REQUIREMENTS=release ",
+        "python": "3.8"
+      },
+      {
+        "env": "BUILD=test-storage DAV_SERVER=xandikos REQUIREMENTS=release ",
+        "python": "3.8"
+      },
+      {
+        "env": "BUILD=test REQUIREMENTS=minimal",
+        "python": "3.8"
+      },
+      {
+        "env": "BUILD=test-storage DAV_SERVER=radicale REQUIREMENTS=minimal ",
+        "python": "3.8"
+      },
+      {
+        "env": "BUILD=test-storage DAV_SERVER=xandikos REQUIREMENTS=minimal ",
+        "python": "3.8"
       },
       {
         "env": "BUILD=test ETESYNC_TESTS=true REQUIREMENTS=latest",

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,10 +9,21 @@ Package maintainers and users who have to manually update their installation
 may want to subscribe to `GitHub's tag feed
 <https://github.com/pimutils/vdirsyncer/tags.atom>`_.
 
+Version 0.16.8
+==============
+
+*released 09 June 2020*
+
+- Support Python 3.7 and 3.8.
+
+This release is functionally identical to 0.16.7.
+It's been tested with recent Python versions, and has been marked as supporting
+them. It will also be the final release supporting Python 3.5 and 3.6.
+
 Version 0.16.7
 ==============
 
-*released on July 19*
+*released on 19 July 2018*
 
 - Fixes for Python 3.7
 

--- a/Makefile
+++ b/Makefile
@@ -96,10 +96,6 @@ style:
 	! git grep -i syncroniz */*
 	! git grep -i 'text/icalendar' */*
 	sphinx-build -W -b html ./docs/ ./docs/_build/html/
-	python3 scripts/make_travisconf.py | diff -b .travis.yml -
-
-travis-conf:
-	python3 scripts/make_travisconf.py > .travis.yml
 
 install-docs:
 	pip install -Ur docs-requirements.txt

--- a/scripts/make_travisconf.py
+++ b/scripts/make_travisconf.py
@@ -3,13 +3,13 @@
 import itertools
 import json
 
-python_versions = ("3.5", "3.6")
+python_versions = ("3.5", "3.6", "3.7", "3.8")
 latest_python = "3.6"
 
 cfg = {}
 
 cfg['sudo'] = True
-cfg['dist'] = 'trusty'
+cfg['dist'] = 'bionic'
 cfg['language'] = 'python'
 cfg['cache'] = 'pip'
 
@@ -61,6 +61,8 @@ for python, requirements in itertools.product(
                     f"DAV_SERVER={dav_server} "
                     f"REQUIREMENTS={requirements} ")
         }
+        if python == '3.5':
+            job['dist'] = 'trusty'
 
         build_prs = dav_server not in ("fastmail", "davical", "icloud")
         if not build_prs:

--- a/scripts/make_travisconf.py
+++ b/scripts/make_travisconf.py
@@ -1,6 +1,7 @@
+#!/usr/bin/env python
+
 import itertools
 import json
-import sys
 
 python_versions = ("3.5", "3.6")
 latest_python = "3.6"
@@ -57,10 +58,8 @@ for python, requirements in itertools.product(
         job = {
             'python': python,
             'env': ("BUILD=test-storage "
-                    "DAV_SERVER={dav_server} "
-                    "REQUIREMENTS={requirements} "
-                    .format(dav_server=dav_server,
-                            requirements=requirements))
+                    f"DAV_SERVER={dav_server} "
+                    f"REQUIREMENTS={requirements} ")
         }
 
         build_prs = dav_server not in ("fastmail", "davical", "icloud")
@@ -82,4 +81,5 @@ matrix.append({
 #     'env': 'BUILD=test'
 # })
 
-json.dump(cfg, sys.stdout, sort_keys=True, indent=2)
+with open('.travis.yml', 'w') as output:
+    json.dump(cfg, output, sort_keys=True, indent=2)

--- a/setup.py
+++ b/setup.py
@@ -89,6 +89,8 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Internet',
         'Topic :: Utilities',
     ],


### PR DESCRIPTION
As soon as this turns green, I'll make a 0.16.8 release, which will be the last to support Python 3.5 and 3.6.

At that point, support for those two pythons will be dropped. They no longer receive bugfix support upstream anyway, so anyone wanting _any_ for of bugfixing, should upgrade to an upstream supported Python.