### PR TITLE
Fixing test_verbosity

### DIFF
--- a/tests/system/cli/test_sync.py
+++ b/tests/system/cli/test_sync.py
@@ -123,7 +123,7 @@ def test_verbosity(tmpdir, runner):
     runner.write_with_general('')
     result = runner.invoke(['--verbosity=HAHA', 'sync'])
     assert result.exception
-    assert 'invalid value for "--verbosity"' in result.output.lower()
+    assert "invalid value for '--verbosity'" in result.output.lower()
 
 
 def test_collections_cache_invalidation(tmpdir, runner):


### PR DESCRIPTION
tests/system/cli/test_sync.py:
The test test_verbosity checked for the occurence of "--verbosity",
whereas it is '--verbosity'. This commit changes the check to match for
the latter.

Closes #828