### PR TITLE
fixed password.fetch option not using environment

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -13,6 +13,7 @@ In alphabetical order:
 - Markus Unterwaditzer
 - Michael Adler
 - Thomas Weißschuh
+- Witcher01
 
 Special thanks goes to:
 

--- a/vdirsyncer/cli/fetchparams.py
+++ b/vdirsyncer/cli/fetchparams.py
@@ -75,7 +75,11 @@ def _fetch_value(opts, key):
 
 def _strategy_command(*command):
     import subprocess
-    command = (expand_path(command[0]),) + command[1:]
+
+    # normalize path of every path member
+    # if there is no path specified then nothing will happen
+    command = map(expand_path, command)
+
     try:
         stdout = subprocess.check_output(command, universal_newlines=True)
         return stdout.strip('\n')


### PR DESCRIPTION
the '_strategy_command' in 'fetchparams.cli' did not expand the path of
every argument, but only the first one (being the command to be
executed).
i fixed the '_strategy_command' function to apply the 'expand_path'
function to every member of the commands list.
this is in reply to issue #821