### PR TITLE
contrib/systemd: implement service timeout

### DIFF
--- a/contrib/vdirsyncer.service
+++ b/contrib/vdirsyncer.service
@@ -4,4 +4,5 @@ Documentation=https://vdirsyncer.readthedocs.org/
 
 [Service]
 ExecStart=/usr/bin/vdirsyncer sync
-Type=oneshot
+RuntimeMaxSec=30s
+Restart=on-failure

--- a/contrib/vdirsyncer.service
+++ b/contrib/vdirsyncer.service
@@ -4,5 +4,5 @@ Documentation=https://vdirsyncer.readthedocs.org/
 
 [Service]
 ExecStart=/usr/bin/vdirsyncer sync
-RuntimeMaxSec=30s
+RuntimeMaxSec=3m
 Restart=on-failure


### PR DESCRIPTION
Sometimes while doing a suspend/resume cycle vdirsyncer can hang in the
middle of sync, and it never bails out afterwards.

Implement a systemd service change that works around this:

* use `simple` (a default) type for `RuntimeMaxSec` to be effective
* actually set `RuntimeMaxSec` to 30 seconds
* trigger service restart on failure

Signed-off-by: Oleksandr Natalenko <oleksandr@natalenko.name>