### PR TITLE
Added option to skip objects the remote fails to provide

### DIFF
--- a/vdirsyncer/storage/dav.py
+++ b/vdirsyncer/storage/dav.py
@@ -367,7 +367,7 @@ class DAVSession:
 
     def __init__(self, url, username='', password='', verify=True, auth=None,
                  useragent=USERAGENT, verify_fingerprint=None,
-                 auth_cert=None):
+                 auth_cert=None, ignore_missing_href=False):
         self._settings = {
             'cert': prepare_client_cert(auth_cert),
             'auth': prepare_auth(auth, username, password)
@@ -376,6 +376,7 @@ class DAVSession:
 
         self.useragent = useragent
         self.url = url.rstrip('/') + '/'
+        self.ignore_missing_href = ignore_missing_href
 
         self._session = requests.session()
 
@@ -504,7 +505,8 @@ class DAVStorage(Storage):
             else:
                 rv.append((href, Item(raw), etag))
         for href in hrefs_left:
-            raise exceptions.NotFoundError(href)
+            if not self.session.ignore_missing_href:
+                raise exceptions.NotFoundError(href)
         return rv
 
     def _put(self, href, item, etag):


### PR DESCRIPTION
To deal with a broken CalDAV implementation (and all-around terrible product) SmarterMail, I needed to be able to skip remote objects that are listed but can't be queried. It even fails to render them in its own calendar webinterface. It seems to fail on certain special characters that can be introduced by external calendar invites. There is little chance it will be fixed upstream, so this seemed the best solution.

Does this feature make sense, as does its implementation?