### PR TITLE
metasync: use None as no-value and delete missing values on syncing

### DIFF
--- a/tests/storage/__init__.py
+++ b/tests/storage/__init__.py
@@ -282,12 +282,12 @@ class StorageTests:
 
     def test_metadata(self, requires_metadata, s):
         if not getattr(self, 'dav_server', ''):
-            assert not s.get_meta('color')
-            assert not s.get_meta('displayname')
+            assert s.get_meta('color') is None
+            assert s.get_meta('displayname') is None
 
         try:
             s.set_meta('color', None)
-            assert not s.get_meta('color')
+            assert s.get_meta('color') is None
             s.set_meta('color', '#ff0000')
             assert s.get_meta('color') == '#ff0000'
         except exceptions.UnsupportedMetadataError:

--- a/tests/unit/test_metasync.py
+++ b/tests/unit/test_metasync.py
@@ -30,6 +30,10 @@ def test_basic(monkeypatch):
     metasync(a, b, status, keys=['foo'])
     assert a.get_meta('foo') == b.get_meta('foo') == 'bar'
 
+    a.set_meta('foo', None)
+    metasync(a, b, status, keys=['foo'])
+    assert a.get_meta('foo') is None and b.get_meta('foo') is None
+
     a.set_meta('foo', 'baz')
     metasync(a, b, status, keys=['foo'])
     assert a.get_meta('foo') == b.get_meta('foo') == 'baz'
@@ -151,7 +155,7 @@ def test_fuzzing(a, b, status, keys, conflict_resolution):
              keys=keys, conflict_resolution=conflict_resolution)
 
     for key in keys:
-        s = status.get(key, '')
+        s = status.get(key)
         assert a.get_meta(key) == b.get_meta(key) == s
-        if expected_values.get(key, '') and s:
+        if expected_values.get(key) and s:
             assert s == expected_values[key]

--- a/vdirsyncer/metasync.py
+++ b/vdirsyncer/metasync.py
@@ -14,20 +14,27 @@ class MetaSyncConflict(MetaSyncError):
     key = None
 
 
+def status_set_key(status, key, value):
+    if value is None:
+        status.pop(key, None)
+    else:
+        status[key] = value
+
+
 def metasync(storage_a, storage_b, status, keys, conflict_resolution=None):
     def _a_to_b():
         logger.info(f'Copying {key} to {storage_b}')
         storage_b.set_meta(key, a)
-        status[key] = a
+        status_set_key(status, key, a)
 
     def _b_to_a():
         logger.info(f'Copying {key} to {storage_a}')
         storage_a.set_meta(key, b)
-        status[key] = b
+        status_set_key(status, key, b)
 
     def _resolve_conflict():
         if a == b:
-            status[key] = a
+            status_set_key(status, key, a)
         elif conflict_resolution == 'a wins':
             _a_to_b()
         elif conflict_resolution == 'b wins':

--- a/vdirsyncer/storage/base.py
+++ b/vdirsyncer/storage/base.py
@@ -223,6 +223,9 @@ class Storage(metaclass=StorageMeta):
 
         :param key: The metadata key.
         :type key: unicode
+
+        Return:
+        The metadata or None, if metadata is missing
         '''
 
         raise NotImplementedError('This storage does not support metadata.')
@@ -232,7 +235,7 @@ class Storage(metaclass=StorageMeta):
 
         :param key: The metadata key.
         :type key: unicode
-        :param value: The value.
+        :param value: The value.  Use None to delete the data.
         :type value: unicode
         '''
 
@@ -241,6 +244,6 @@ class Storage(metaclass=StorageMeta):
 
 def normalize_meta_value(value):
     # `None` is returned by iCloud for empty properties.
-    if not value or value == 'None':
-        value = ''
-    return value.strip()
+    if value is None or value == 'None':
+        return
+    return value.strip() if value else ''

--- a/vdirsyncer/storage/dav.py
+++ b/vdirsyncer/storage/dav.py
@@ -670,7 +670,6 @@ class DAVStorage(Storage):
             text = normalize_meta_value(getattr(prop, 'text', None))
             if text:
                 return text
-        return ''
 
     def set_meta(self, key, value):
         try:
@@ -680,17 +679,22 @@ class DAVStorage(Storage):
 
         lxml_selector = f'{{{namespace}}}{tagname}'
         element = etree.Element(lxml_selector)
-        element.text = normalize_meta_value(value)
+        if value is None:
+            action = 'remove'
+        else:
+            element.text = normalize_meta_value(value)
+            action = 'set'
 
         data = '''<?xml version="1.0" encoding="utf-8" ?>
             <D:propertyupdate xmlns:D="DAV:">
-                <D:set>
+                <D:{action}>
                     <D:prop>
                         {}
                     </D:prop>
-                </D:set>
+                </D:{action}>
             </D:propertyupdate>
-        '''.format(etree.tostring(element, encoding='unicode')).encode('utf-8')
+        '''.format(etree.tostring(element, encoding='unicode'),
+                   action=action).encode('utf-8')
 
         self.session.request(
             'PROPPATCH', '',

--- a/vdirsyncer/storage/filesystem.py
+++ b/vdirsyncer/storage/filesystem.py
@@ -175,14 +175,19 @@ class FilesystemStorage(Storage):
             with open(fpath, 'rb') as f:
                 return normalize_meta_value(f.read().decode(self.encoding))
         except OSError as e:
-            if e.errno == errno.ENOENT:
-                return ''
-            else:
+            if e.errno != errno.ENOENT:
                 raise
 
     def set_meta(self, key, value):
         value = normalize_meta_value(value)
 
         fpath = os.path.join(self.path, key)
+        if value is None:
+            try:
+                os.remove(fpath)
+            except OSError:
+                pass
+            return
+
         with atomic_write(fpath, mode='wb', overwrite=True) as f:
             f.write(value.encode(self.encoding))

--- a/vdirsyncer/storage/memory.py
+++ b/vdirsyncer/storage/memory.py
@@ -70,4 +70,7 @@ class MemoryStorage(Storage):
         return normalize_meta_value(self.metadata.get(key))
 
     def set_meta(self, key, value):
-        self.metadata[key] = normalize_meta_value(value)
+        if value is None:
+            self.metadata.pop(key, None)
+        else:
+            self.metadata[key] = normalize_meta_value(value)


### PR DESCRIPTION
- change the interface of Storage.get_meta() and .set_meta()  to use '' as the empty value and None as missing value.

- When a property is missing (e.g calendar-color was removed) in the filesystem storage delete the 'color' file, and in the WebDAV storage issue propertyupdate/remove call.

- remove the property from [status]/[pair]/[collection].metadata

I have adjusted, but not run the test suite.  On the other side I tested on real system: source is CalDAV - destination is filesystem; and source is CalDAV, destination is CalDAV (another account)