### PR TITLE
WIP: Use tox to run tests

### DIFF
--- a/.builds/tests-release.yaml
+++ b/.builds/tests-release.yaml
@@ -6,33 +6,26 @@ packages:
   - docker-compose
   - python-pip
   - twine
+  - python-tox
+  - python-pre-commit
 sources:
   - https://github.com/pimutils/vdirsyncer
 secrets:
   - a36c8ba3-fba0-4338-b402-6aea0fbe771e
 environment:
-  BUILD: test
   CI: true
   CODECOV_TOKEN: b834a3c5-28fa-4808-9bdb-182210069c79
   DAV_SERVER: baikal radicale xandikos
-  REQUIREMENTS: release
   # TODO: ETESYNC_TESTS
 tasks:
   - setup: |
       sudo systemctl start docker
-      cd vdirsyncer
-      make -e install-dev -e install-docs
   - test: |
       cd vdirsyncer
-      # Non-system python is used for packages:
-      export PATH=$PATH:~/.local/bin/
-      make -e ci-test
-      make -e ci-test-storage
-  - style: |
+      tox
+  - lint: |
       cd vdirsyncer
-      # Non-system python is used for packages:
-      export PATH=$PATH:~/.local/bin/
-      make -e style
+      pre-commit run --all
       git describe --exact-match --tags || complete-build
   - publish: |
       cd vdirsyncer

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,8 +6,9 @@ addopts =
   --tb=short
   --cov-config .coveragerc
   --cov=vdirsyncer
-  --cov-report=term-missing
+  --cov-report=term-missing:skip-covered
   --no-cov-on-fail
+  --color=yes
 # filterwarnings=error
 
 [flake8]

--- a/tests/storage/conftest.py
+++ b/tests/storage/conftest.py
@@ -46,6 +46,7 @@ def dockerised_server(name, container_port, exposed_port):
             [
                 "docker",
                 "run",
+                "--rm",
                 "--detach",
                 "--publish",
                 f"{exposed_port}:{container_port}",

--- a/tests/storage/dav/__init__.py
+++ b/tests/storage/dav/__init__.py
@@ -13,6 +13,7 @@ from vdirsyncer.vobject import Item
 
 
 dav_server = os.environ.get("DAV_SERVER", "skip")
+
 ServerMixin = get_server_mixin(dav_server)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,69 @@
+[tox]
+envlist = py39, docs
+
+# TODO: fastmail,icloud,owncloud,nextcloud
+
+[testenv]
+deps =
+  -r test-requirements.txt
+  codecov
+commands =
+  pytest tests/ {posargs}
+  codecov
+passenv =
+  CI
+  CODECOV_TOKEN
+  DAV_SERVER
+  DETERMINISTIC_TESTS
+setenv =
+  COVERAGE={env:CI:false}
+  PYTHONPATH={toxinidir}
+
+[testenv:storage]
+# TODO: run on a single storage
+# mostly for manual
+# pass env for all optional variables
+#        set them to __undefined__ by default
+#        this way it FAILS if missing
+
+[testenv:minimal]
+skip_install = true
+commands =
+  sh -c "pip install $(python setup.py minimal_requirements -q | tail -n +2)"
+  # TODO: Actually call parent cmds here
+  pytest tests/ {posargs}
+  codecov
+setenv =
+  PYTHONPATH={toxinidir}
+allowlist_externals =
+  sh
+
+[testenv:check]
+skip_install = true
+deps = pre-commit
+commands = pre-commint run --all
+
+[testenv:docs]
+deps =
+  -r docs-requirements.txt
+commands =
+  make -C docs html
+  sphinx-build -W -b linkcheck ./docs/ ./docs/_build/linkcheck/
+whitelist_externals =
+  make
+
+# release-deb:
+# 	sh scripts/release-deb.sh debian jessie
+# 	sh scripts/release-deb.sh debian stretch
+# 	sh scripts/release-deb.sh ubuntu trusty
+# 	sh scripts/release-deb.sh ubuntu xenial
+# 	sh scripts/release-deb.sh ubuntu zesty
+
+# TODO: ETESYNC_TESTS
+# TEST_EXTRA_PACKAGES += git+https://github.com/etesync/journal-manager@v0.5.2
+# TEST_EXTRA_PACKAGES += django djangorestframework==3.8.2 wsgi_intercept drf-nested-routers
+
+# [ "$(ETESYNC_TESTS)" = "false" ] || pip install -Ue .[etesync]
+# set -xe && if [ "$(REQUIREMENTS)" = "minimal" ]; then \
+#        pip install -U --force-reinstall $$(python setup.py --quiet minimal_requirements); \
+# fi


### PR DESCRIPTION
If this works, running tests locally should be just `tox` or `tox -e unit` to just run unit tests.

The `minimal` tests are not-yet ported though, since we need to pass minimal dependencies to `tox`.