### PR TITLE
Add a command to print the current config

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,9 @@ Version 0.19.0
 - Add "description" and "order" as metadata.  These fetch the CalDAV:
   calendar-description, CardDAV:addressbook-description and apple-ns:calendar-order
   properties.
+- Add a new "showconfig" status. This prints *some* configuration values as
+  JSON. This is intended to be used by external tools and helpers that interact
+  with ``vdirsyncer``.
 
 Version 0.18.0
 ==============

--- a/tests/system/cli/test_discover.py
+++ b/tests/system/cli/test_discover.py
@@ -239,3 +239,45 @@ def test_collection_required(a_requires, b_requires, tmpdir, runner, monkeypatch
         assert (
             "One or more storages don't support `collections = null`." in result.output
         )
+
+
+def test_showconfig(tmpdir, runner):
+    runner.write_with_general(
+        dedent(
+            """
+    [storage foo]
+    type = "filesystem"
+    path = "{0}/foo/"
+    fileext = ".txt"
+
+    [storage bar]
+    type = "filesystem"
+    path = "{0}/bar/"
+    fileext = ".txt"
+
+    [pair foobar]
+    a = "foo"
+    b = "bar"
+    collections = ["from a"]
+    """
+        ).format(str(tmpdir))
+    )
+
+    result = runner.invoke(["showconfig"])
+    assert not result.exception
+    assert json.loads(result.output) == {
+        "storages": [
+            {
+                "type": "filesystem",
+                "path": f"{tmpdir}/foo/",
+                "fileext": ".txt",
+                "instance_name": "foo",
+            },
+            {
+                "type": "filesystem",
+                "path": f"{tmpdir}/bar/",
+                "fileext": ".txt",
+                "instance_name": "bar",
+            },
+        ]
+    }

--- a/vdirsyncer/cli/__init__.py
+++ b/vdirsyncer/cli/__init__.py
@@ -1,4 +1,5 @@
 import functools
+import json
 import logging
 import sys
 
@@ -275,3 +276,16 @@ def repair(ctx, collection, repair_unsafe_uid):
     )
     click.confirm("Do you want to continue?", abort=True)
     repair_collection(ctx.config, collection, repair_unsafe_uid=repair_unsafe_uid)
+
+
+@app.command()
+@pass_context
+@catch_errors
+def showconfig(ctx: AppContext):
+    """Show the current configuration.
+
+    This is mostly intended to be used by scripts or other integrations.
+    If you need additional information in this dump, please reach out.
+    """
+    config = {"storages": list(ctx.config.storages.values())}
+    click.echo(json.dumps(config, indent=2))


### PR DESCRIPTION
This is intended to be used by external tools and integrations (such as daemons which trigger `vdirsyncer` when there's a change in a collection).