### PR TITLE
Initial asyncio support

### DIFF
--- a/.builds/archlinux.yaml
+++ b/.builds/archlinux.yaml
@@ -19,6 +19,10 @@ packages:
   - python-pytest-cov
   - python-pytest-httpserver
   - python-trustme
+  - python-pytest-asyncio
+  - python-aiohttp
+  - python-aiostream
+  - python-aioresponses
 sources:
   - https://github.com/pimutils/vdirsyncer
 environment:

--- a/.builds/archlinux.yaml
+++ b/.builds/archlinux.yaml
@@ -14,6 +14,7 @@ packages:
   - python-click-threading
   - python-requests
   - python-requests-toolbelt
+  - python-aiohttp-oauthlib
   # Test dependencies:
   - python-hypothesis
   - python-pytest-cov

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,12 +15,20 @@ Version 0.19.0
 - Add "description" and "order" as metadata.  These fetch the CalDAV:
   calendar-description, CardDAV:addressbook-description and apple-ns:calendar-order
   properties.
-- Add a new "showconfig" status. This prints *some* configuration values as
+- Add a new ``showconfig`` status. This prints *some* configuration values as
   JSON. This is intended to be used by external tools and helpers that interact
   with ``vdirsyncer``.
-- Update TLS-related tests that were failing due to weak MDs.
+- Update TLS-related tests that were failing due to weak MDs. :gh:`903`
 - ``pytest-httpserver`` and ``trustme`` are now required for tests.
 - ``pytest-localserver`` is no longer required for tests.
+- Multithreaded support has been dropped. The ``"--max-workers`` has been removed.
+- A new ``asyncio`` backend is now used. So far, this shows substantial speed
+  improvements in ``discovery`` and ``metasync``, but little change in `sync`.
+  This will likely continue improving over time. :gh:`906`
+- Support for `md5` and `sha1` certificate fingerprints has been dropped. If
+  you're validating certificate fingerprints, use `sha256` instead.
+- The ``google`` storage types no longer require ``requests-oauthlib``, but
+  require ``python-aiohttp-oauthlib`` instead.
 
 Version 0.18.0
 ==============

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,7 @@ addopts =
   --cov=vdirsyncer
   --cov-report=term-missing
   --no-cov-on-fail
+# filterwarnings=error
 
 [flake8]
 application-import-names = tests,vdirsyncer

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
     install_requires=requirements,
     # Optional dependencies
     extras_require={
-        "google": ["requests-oauthlib"],
+        "google": ["aiohttp-oauthlib"],
         "etesync": ["etesync==0.5.2", "django<2.0"],
     },
     # Build dependencies

--- a/setup.py
+++ b/setup.py
@@ -13,14 +13,14 @@ requirements = [
     # https://github.com/mitsuhiko/click/issues/200
     "click>=5.0,<9.0",
     "click-log>=0.3.0, <0.4.0",
-    # https://github.com/pimutils/vdirsyncer/issues/478
-    "click-threading>=0.5",
     "requests >=2.20.0",
     # https://github.com/sigmavirus24/requests-toolbelt/pull/28
     # And https://github.com/sigmavirus24/requests-toolbelt/issues/54
     "requests_toolbelt >=0.4.0",
     # https://github.com/untitaker/python-atomicwrites/commit/4d12f23227b6a944ab1d99c507a69fdbc7c9ed6d  # noqa
     "atomicwrites>=0.1.7",
+    "aiohttp>=3.7.1,<4.0.0",
+    "aiostream>=0.4.3,<0.5.0",
 ]
 
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,3 +3,5 @@ pytest
 pytest-cov
 pytest-httpserver
 trustme
+pytest-asyncio
+aioresponses

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ General-purpose fixtures for vdirsyncer's testsuite.
 import logging
 import os
 
+import aiohttp
 import click_log
 import pytest
 from hypothesis import HealthCheck
@@ -52,3 +53,18 @@ elif os.environ.get("CI", "false").lower() == "true":
     settings.load_profile("ci")
 else:
     settings.load_profile("dev")
+
+
+@pytest.fixture
+async def aio_session(event_loop):
+    async with aiohttp.ClientSession() as session:
+        yield session
+
+
+@pytest.fixture
+async def aio_connector(event_loop):
+    conn = aiohttp.TCPConnector(limit_per_host=16)
+    try:
+        yield conn
+    finally:
+        await conn.close()

--- a/tests/storage/dav/__init__.py
+++ b/tests/storage/dav/__init__.py
@@ -1,8 +1,9 @@
 import os
 import uuid
 
+import aiohttp
+import aiostream
 import pytest
-import requests.exceptions
 
 from .. import get_server_mixin
 from .. import StorageTests
@@ -19,30 +20,33 @@ class DAVStorageTests(ServerMixin, StorageTests):
     dav_server = dav_server
 
     @pytest.mark.skipif(dav_server == "radicale", reason="Radicale is very tolerant.")
-    def test_dav_broken_item(self, s):
+    @pytest.mark.asyncio
+    async def test_dav_broken_item(self, s):
         item = Item("HAHA:YES")
-        with pytest.raises((exceptions.Error, requests.exceptions.HTTPError)):
-            s.upload(item)
-        assert not list(s.list())
+        with pytest.raises((exceptions.Error, aiohttp.ClientResponseError)):
+            await s.upload(item)
+        assert not await aiostream.stream.list(s.list())
 
-    def test_dav_empty_get_multi_performance(self, s, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_dav_empty_get_multi_performance(self, s, monkeypatch):
         def breakdown(*a, **kw):
             raise AssertionError("Expected not to be called.")
 
         monkeypatch.setattr("requests.sessions.Session.request", breakdown)
 
         try:
-            assert list(s.get_multi([])) == []
+            assert list(await aiostream.stream.list(s.get_multi([]))) == []
         finally:
             # Make sure monkeypatch doesn't interfere with DAV server teardown
             monkeypatch.undo()
 
-    def test_dav_unicode_href(self, s, get_item, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_dav_unicode_href(self, s, get_item, monkeypatch):
         if self.dav_server == "radicale":
             pytest.skip("Radicale is unable to deal with unicode hrefs")
 
         monkeypatch.setattr(s, "_get_href", lambda item: item.ident + s.fileext)
         item = get_item(uid="град сатану" + str(uuid.uuid4()))
-        href, etag = s.upload(item)
-        item2, etag2 = s.get(href)
+        href, etag = await s.upload(item)
+        item2, etag2 = await s.get(href)
         assert_item_equals(item, item2)

--- a/tests/storage/etesync/test_main.py
+++ b/tests/storage/etesync/test_main.py
@@ -58,7 +58,7 @@ class EtesyncTests(StorageTests):
         )
         assert r.status_code == 200
 
-        def inner(collection="test"):
+        async def inner(collection="test"):
             rv = {
                 "email": "test@localhost",
                 "db_path": str(tmpdir.join("etesync.db")),

--- a/tests/storage/servers/baikal/__init__.py
+++ b/tests/storage/servers/baikal/__init__.py
@@ -3,13 +3,21 @@ import pytest
 
 class ServerMixin:
     @pytest.fixture
-    def get_storage_args(self, request, tmpdir, slow_create_collection, baikal_server):
-        def inner(collection="test"):
+    def get_storage_args(
+        self,
+        request,
+        tmpdir,
+        slow_create_collection,
+        baikal_server,
+        aio_connector,
+    ):
+        async def inner(collection="test"):
             base_url = "http://127.0.0.1:8002/"
             args = {
                 "url": base_url,
                 "username": "baikal",
                 "password": "baikal",
+                "connector": aio_connector,
             }
 
             if self.storage_class.fileext == ".vcf":
@@ -18,7 +26,11 @@ class ServerMixin:
                 args["url"] = base_url + "cal.php/"
 
             if collection is not None:
-                args = slow_create_collection(self.storage_class, args, collection)
+                args = await slow_create_collection(
+                    self.storage_class,
+                    args,
+                    collection,
+                )
             return args
 
         return inner

--- a/tests/storage/servers/davical/__init__.py
+++ b/tests/storage/servers/davical/__init__.py
@@ -27,7 +27,7 @@ class ServerMixin:
 
     @pytest.fixture
     def get_storage_args(self, davical_args, request):
-        def inner(collection="test"):
+        async def inner(collection="test"):
             if collection is None:
                 return davical_args
 

--- a/tests/storage/servers/fastmail/__init__.py
+++ b/tests/storage/servers/fastmail/__init__.py
@@ -11,7 +11,7 @@ class ServerMixin:
             # See https://github.com/pimutils/vdirsyncer/issues/824
             pytest.skip("Fastmail has non-standard VTODO support.")
 
-        def inner(collection="test"):
+        async def inner(collection="test"):
             args = {
                 "username": os.environ["FASTMAIL_USERNAME"],
                 "password": os.environ["FASTMAIL_PASSWORD"],

--- a/tests/storage/servers/icloud/__init__.py
+++ b/tests/storage/servers/icloud/__init__.py
@@ -11,7 +11,7 @@ class ServerMixin:
             # See https://github.com/pimutils/vdirsyncer/pull/593#issuecomment-285941615  # noqa
             pytest.skip("iCloud doesn't support anything else than VEVENT")
 
-        def inner(collection="test"):
+        async def inner(collection="test"):
             args = {
                 "username": os.environ["ICLOUD_USERNAME"],
                 "password": os.environ["ICLOUD_PASSWORD"],

--- a/tests/storage/servers/radicale/__init__.py
+++ b/tests/storage/servers/radicale/__init__.py
@@ -9,17 +9,23 @@ class ServerMixin:
         tmpdir,
         slow_create_collection,
         radicale_server,
+        aio_connector,
     ):
-        def inner(collection="test"):
+        async def inner(collection="test"):
             url = "http://127.0.0.1:8001/"
             args = {
                 "url": url,
                 "username": "radicale",
                 "password": "radicale",
+                "connector": aio_connector,
             }
 
             if collection is not None:
-                args = slow_create_collection(self.storage_class, args, collection)
+                args = await slow_create_collection(
+                    self.storage_class,
+                    args,
+                    collection,
+                )
             return args
 
         return inner

--- a/tests/storage/servers/xandikos/__init__.py
+++ b/tests/storage/servers/xandikos/__init__.py
@@ -9,13 +9,19 @@ class ServerMixin:
         tmpdir,
         slow_create_collection,
         xandikos_server,
+        aio_connector,
     ):
-        def inner(collection="test"):
+        async def inner(collection="test"):
             url = "http://127.0.0.1:8000/"
-            args = {"url": url}
+            args = {"url": url, "connector": aio_connector}
 
             if collection is not None:
-                args = slow_create_collection(self.storage_class, args, collection)
+                args = await slow_create_collection(
+                    self.storage_class,
+                    args,
+                    collection,
+                )
+
             return args
 
         return inner

--- a/tests/storage/test_filesystem.py
+++ b/tests/storage/test_filesystem.py
@@ -1,5 +1,6 @@
 import subprocess
 
+import aiostream
 import pytest
 
 from . import StorageTests
@@ -12,10 +13,10 @@ class TestFilesystemStorage(StorageTests):
 
     @pytest.fixture
     def get_storage_args(self, tmpdir):
-        def inner(collection="test"):
+        async def inner(collection="test"):
             rv = {"path": str(tmpdir), "fileext": ".txt", "collection": collection}
             if collection is not None:
-                rv = self.storage_class.create_collection(**rv)
+                rv = await self.storage_class.create_collection(**rv)
             return rv
 
         return inner
@@ -26,7 +27,8 @@ class TestFilesystemStorage(StorageTests):
             f.write("stub")
             self.storage_class(str(tmpdir) + "/hue", ".txt")
 
-    def test_broken_data(self, tmpdir):
+    @pytest.mark.asyncio
+    async def test_broken_data(self, tmpdir):
         s = self.storage_class(str(tmpdir), ".txt")
 
         class BrokenItem:
@@ -35,64 +37,70 @@ class TestFilesystemStorage(StorageTests):
             ident = uid
 
         with pytest.raises(TypeError):
-            s.upload(BrokenItem)
+            await s.upload(BrokenItem)
         assert not tmpdir.listdir()
 
-    def test_ident_with_slash(self, tmpdir):
+    @pytest.mark.asyncio
+    async def test_ident_with_slash(self, tmpdir):
         s = self.storage_class(str(tmpdir), ".txt")
-        s.upload(Item("UID:a/b/c"))
+        await s.upload(Item("UID:a/b/c"))
         (item_file,) = tmpdir.listdir()
         assert "/" not in item_file.basename and item_file.isfile()
 
-    def test_ignore_tmp_files(self, tmpdir):
+    @pytest.mark.asyncio
+    async def test_ignore_tmp_files(self, tmpdir):
         """Test that files with .tmp suffix beside .ics files are ignored."""
         s = self.storage_class(str(tmpdir), ".ics")
-        s.upload(Item("UID:xyzxyz"))
+        await s.upload(Item("UID:xyzxyz"))
         (item_file,) = tmpdir.listdir()
         item_file.copy(item_file.new(ext="tmp"))
         assert len(tmpdir.listdir()) == 2
-        assert len(list(s.list())) == 1
+        assert len(await aiostream.stream.list(s.list())) == 1
 
-    def test_ignore_tmp_files_empty_fileext(self, tmpdir):
+    @pytest.mark.asyncio
+    async def test_ignore_tmp_files_empty_fileext(self, tmpdir):
         """Test that files with .tmp suffix are ignored with empty fileext."""
         s = self.storage_class(str(tmpdir), "")
-        s.upload(Item("UID:xyzxyz"))
+        await s.upload(Item("UID:xyzxyz"))
         (item_file,) = tmpdir.listdir()
         item_file.copy(item_file.new(ext="tmp"))
         assert len(tmpdir.listdir()) == 2
         # assert False, tmpdir.listdir() # enable to see the created filename
-        assert len(list(s.list())) == 1
+        assert len(await aiostream.stream.list(s.list())) == 1
 
-    def test_ignore_files_typical_backup(self, tmpdir):
+    @pytest.mark.asyncio
+    async def test_ignore_files_typical_backup(self, tmpdir):
         """Test file-name ignorance with typical backup ending ~."""
         ignorext = "~"  # without dot
 
         storage = self.storage_class(str(tmpdir), "", fileignoreext=ignorext)
-        storage.upload(Item("UID:xyzxyz"))
+        await storage.upload(Item("UID:xyzxyz"))
         (item_file,) = tmpdir.listdir()
         item_file.copy(item_file.new(basename=item_file.basename + ignorext))
 
         assert len(tmpdir.listdir()) == 2
-        assert len(list(storage.list())) == 1
+        assert len(await aiostream.stream.list(storage.list())) == 1
 
-    def test_too_long_uid(self, tmpdir):
+    @pytest.mark.asyncio
+    async def test_too_long_uid(self, tmpdir):
         storage = self.storage_class(str(tmpdir), ".txt")
         item = Item("UID:" + "hue" * 600)
 
-        href, etag = storage.upload(item)
+        href, etag = await storage.upload(item)
         assert item.uid not in href
 
-    def test_post_hook_inactive(self, tmpdir, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_post_hook_inactive(self, tmpdir, monkeypatch):
         def check_call_mock(*args, **kwargs):
             raise AssertionError()
 
         monkeypatch.setattr(subprocess, "call", check_call_mock)
 
         s = self.storage_class(str(tmpdir), ".txt", post_hook=None)
-        s.upload(Item("UID:a/b/c"))
+        await s.upload(Item("UID:a/b/c"))
 
-    def test_post_hook_active(self, tmpdir, monkeypatch):
-
+    @pytest.mark.asyncio
+    async def test_post_hook_active(self, tmpdir, monkeypatch):
         calls = []
         exe = "foo"
 
@@ -104,14 +112,17 @@ class TestFilesystemStorage(StorageTests):
         monkeypatch.setattr(subprocess, "call", check_call_mock)
 
         s = self.storage_class(str(tmpdir), ".txt", post_hook=exe)
-        s.upload(Item("UID:a/b/c"))
+        await s.upload(Item("UID:a/b/c"))
         assert calls
 
-    def test_ignore_git_dirs(self, tmpdir):
+    @pytest.mark.asyncio
+    async def test_ignore_git_dirs(self, tmpdir):
         tmpdir.mkdir(".git").mkdir("foo")
         tmpdir.mkdir("a")
         tmpdir.mkdir("b")
-        assert {c["collection"] for c in self.storage_class.discover(str(tmpdir))} == {
-            "a",
-            "b",
+
+        expected = {"a", "b"}
+        actual = {
+            c["collection"] async for c in self.storage_class.discover(str(tmpdir))
         }
+        assert actual == expected

--- a/tests/storage/test_http_with_singlefile.py
+++ b/tests/storage/test_http_with_singlefile.py
@@ -1,5 +1,7 @@
+import aiostream
 import pytest
-from requests import Response
+from aioresponses import aioresponses
+from aioresponses import CallbackResult
 
 import vdirsyncer.storage.http
 from . import StorageTests
@@ -14,32 +16,33 @@ class CombinedStorage(Storage):
     _repr_attributes = ("url", "path")
     storage_name = "http_and_singlefile"
 
-    def __init__(self, url, path, **kwargs):
+    def __init__(self, url, path, *, connector, **kwargs):
         if kwargs.get("collection", None) is not None:
             raise ValueError()
 
         super().__init__(**kwargs)
         self.url = url
         self.path = path
-        self._reader = vdirsyncer.storage.http.HttpStorage(url=url)
+        self._reader = vdirsyncer.storage.http.HttpStorage(url=url, connector=connector)
         self._reader._ignore_uids = False
         self._writer = SingleFileStorage(path=path)
 
-    def list(self, *a, **kw):
-        return self._reader.list(*a, **kw)
+    async def list(self, *a, **kw):
+        async for item in self._reader.list(*a, **kw):
+            yield item
 
-    def get(self, *a, **kw):
-        self.list()
-        return self._reader.get(*a, **kw)
+    async def get(self, *a, **kw):
+        await aiostream.stream.list(self.list())
+        return await self._reader.get(*a, **kw)
 
-    def upload(self, *a, **kw):
-        return self._writer.upload(*a, **kw)
+    async def upload(self, *a, **kw):
+        return await self._writer.upload(*a, **kw)
 
-    def update(self, *a, **kw):
-        return self._writer.update(*a, **kw)
+    async def update(self, *a, **kw):
+        return await self._writer.update(*a, **kw)
 
-    def delete(self, *a, **kw):
-        return self._writer.delete(*a, **kw)
+    async def delete(self, *a, **kw):
+        return await self._writer.delete(*a, **kw)
 
 
 class TestHttpStorage(StorageTests):
@@ -51,28 +54,37 @@ class TestHttpStorage(StorageTests):
     def setup_tmpdir(self, tmpdir, monkeypatch):
         self.tmpfile = str(tmpdir.ensure("collection.txt"))
 
-        def _request(method, url, *args, **kwargs):
-            assert method == "GET"
-            assert url == "http://localhost:123/collection.txt"
-            assert "vdirsyncer" in kwargs["headers"]["User-Agent"]
-            r = Response()
-            r.status_code = 200
-            try:
-                with open(self.tmpfile, "rb") as f:
-                    r._content = f.read()
-            except OSError:
-                r._content = b""
+        def callback(url, headers, **kwargs):
+            """Read our tmpfile at request time.
 
-            r.headers["Content-Type"] = "text/calendar"
-            r.encoding = "utf-8"
-            return r
+            We can't just read this during test setup since the file get written to
+            during test execution.
 
-        monkeypatch.setattr(vdirsyncer.storage.http, "request", _request)
+            It might make sense to actually run a server serving the local file.
+            """
+            assert headers["User-Agent"].startswith("vdirsyncer/")
+
+            with open(self.tmpfile, "r") as f:
+                body = f.read()
+
+            return CallbackResult(
+                status=200,
+                body=body,
+                headers={"Content-Type": "text/calendar; charset=utf-8"},
+            )
+
+        with aioresponses() as m:
+            m.get("http://localhost:123/collection.txt", callback=callback, repeat=True)
+            yield
 
     @pytest.fixture
-    def get_storage_args(self):
-        def inner(collection=None):
+    def get_storage_args(self, aio_connector):
+        async def inner(collection=None):
             assert collection is None
-            return {"url": "http://localhost:123/collection.txt", "path": self.tmpfile}
+            return {
+                "url": "http://localhost:123/collection.txt",
+                "path": self.tmpfile,
+                "connector": aio_connector,
+            }
 
         return inner

--- a/tests/storage/test_memory.py
+++ b/tests/storage/test_memory.py
@@ -11,4 +11,7 @@ class TestMemoryStorage(StorageTests):
 
     @pytest.fixture
     def get_storage_args(self):
-        return lambda **kw: kw
+        async def inner(**args):
+            return args
+
+        return inner

--- a/tests/storage/test_singlefile.py
+++ b/tests/storage/test_singlefile.py
@@ -11,10 +11,10 @@ class TestSingleFileStorage(StorageTests):
 
     @pytest.fixture
     def get_storage_args(self, tmpdir):
-        def inner(collection="test"):
+        async def inner(collection="test"):
             rv = {"path": str(tmpdir.join("%s.txt")), "collection": collection}
             if collection is not None:
-                rv = self.storage_class.create_collection(**rv)
+                rv = await self.storage_class.create_collection(**rv)
             return rv
 
         return inner

--- a/tests/system/cli/test_sync.py
+++ b/tests/system/cli/test_sync.py
@@ -409,8 +409,8 @@ def test_no_configured_pairs(tmpdir, runner, cmd):
     runner.write_with_general("")
 
     result = runner.invoke([cmd])
-    assert result.output == "critical: Nothing to do.\n"
-    assert result.exception.code == 5
+    assert result.output == ""
+    assert not result.exception
 
 
 @pytest.mark.parametrize(

--- a/tests/system/cli/test_sync.py
+++ b/tests/system/cli/test_sync.py
@@ -50,41 +50,6 @@ def test_sync_inexistant_pair(tmpdir, runner):
     assert "pair foo does not exist." in result.output.lower()
 
 
-def test_debug_connections(tmpdir, runner):
-    runner.write_with_general(
-        dedent(
-            """
-    [pair my_pair]
-    a = "my_a"
-    b = "my_b"
-    collections = null
-
-    [storage my_a]
-    type = "filesystem"
-    path = "{0}/path_a/"
-    fileext = ".txt"
-
-    [storage my_b]
-    type = "filesystem"
-    path = "{0}/path_b/"
-    fileext = ".txt"
-    """
-        ).format(str(tmpdir))
-    )
-
-    tmpdir.mkdir("path_a")
-    tmpdir.mkdir("path_b")
-
-    result = runner.invoke(["discover"])
-    assert not result.exception
-
-    result = runner.invoke(["-vdebug", "sync", "--max-workers=3"])
-    assert "using 3 maximal workers" in result.output.lower()
-
-    result = runner.invoke(["-vdebug", "sync"])
-    assert "using 1 maximal workers" in result.output.lower()
-
-
 def test_empty_storage(tmpdir, runner):
     runner.write_with_general(
         dedent(

--- a/tests/system/cli/test_utils.py
+++ b/tests/system/cli/test_utils.py
@@ -1,3 +1,5 @@
+import pytest
+
 from vdirsyncer import exceptions
 from vdirsyncer.cli.utils import handle_cli_error
 from vdirsyncer.cli.utils import storage_instance_from_config
@@ -15,11 +17,13 @@ def test_handle_cli_error(capsys):
     assert "ayy lmao" in err
 
 
-def test_storage_instance_from_config(monkeypatch):
-    def lol(**kw):
-        assert kw == {"foo": "bar", "baz": 1}
-        return "OK"
+@pytest.mark.asyncio
+async def test_storage_instance_from_config(monkeypatch, aio_connector):
+    class Dummy:
+        def __init__(self, **kw):
+            assert kw == {"foo": "bar", "baz": 1}
 
-    monkeypatch.setitem(storage_names._storages, "lol", lol)
+    monkeypatch.setitem(storage_names._storages, "lol", Dummy)
     config = {"type": "lol", "foo": "bar", "baz": 1}
-    assert storage_instance_from_config(config) == "OK"
+    storage = await storage_instance_from_config(config, connector=aio_connector)
+    assert isinstance(storage, Dummy)

--- a/tests/unit/test_metasync.py
+++ b/tests/unit/test_metasync.py
@@ -12,105 +12,122 @@ from vdirsyncer.storage.base import normalize_meta_value
 from vdirsyncer.storage.memory import MemoryStorage
 
 
-def test_irrelevant_status():
+@pytest.mark.asyncio
+async def test_irrelevant_status():
     a = MemoryStorage()
     b = MemoryStorage()
     status = {"foo": "bar"}
 
-    metasync(a, b, status, keys=())
+    await metasync(a, b, status, keys=())
     assert not status
 
 
-def test_basic(monkeypatch):
+@pytest.mark.asyncio
+async def test_basic(monkeypatch):
     a = MemoryStorage()
     b = MemoryStorage()
     status = {}
 
-    a.set_meta("foo", "bar")
-    metasync(a, b, status, keys=["foo"])
-    assert a.get_meta("foo") == b.get_meta("foo") == "bar"
+    await a.set_meta("foo", "bar")
+    await metasync(a, b, status, keys=["foo"])
+    assert await a.get_meta("foo") == await b.get_meta("foo") == "bar"
 
-    a.set_meta("foo", "baz")
-    metasync(a, b, status, keys=["foo"])
-    assert a.get_meta("foo") == b.get_meta("foo") == "baz"
+    await a.set_meta("foo", "baz")
+    await metasync(a, b, status, keys=["foo"])
+    assert await a.get_meta("foo") == await b.get_meta("foo") == "baz"
 
     monkeypatch.setattr(a, "set_meta", blow_up)
     monkeypatch.setattr(b, "set_meta", blow_up)
-    metasync(a, b, status, keys=["foo"])
-    assert a.get_meta("foo") == b.get_meta("foo") == "baz"
+    await metasync(a, b, status, keys=["foo"])
+    assert await a.get_meta("foo") == await b.get_meta("foo") == "baz"
     monkeypatch.undo()
     monkeypatch.undo()
 
-    b.set_meta("foo", None)
-    metasync(a, b, status, keys=["foo"])
-    assert not a.get_meta("foo") and not b.get_meta("foo")
+    await b.set_meta("foo", None)
+    await metasync(a, b, status, keys=["foo"])
+    assert not await a.get_meta("foo") and not await b.get_meta("foo")
 
 
 @pytest.fixture
-def conflict_state(request):
+@pytest.mark.asyncio
+async def conflict_state(request, event_loop):
     a = MemoryStorage()
     b = MemoryStorage()
     status = {}
-    a.set_meta("foo", "bar")
-    b.set_meta("foo", "baz")
+    await a.set_meta("foo", "bar")
+    await b.set_meta("foo", "baz")
 
     def cleanup():
-        assert a.get_meta("foo") == "bar"
-        assert b.get_meta("foo") == "baz"
-        assert not status
+        async def do_cleanup():
+            assert await a.get_meta("foo") == "bar"
+            assert await b.get_meta("foo") == "baz"
+            assert not status
+
+        event_loop.run_until_complete(do_cleanup())
 
     request.addfinalizer(cleanup)
 
     return a, b, status
 
 
-def test_conflict(conflict_state):
+@pytest.mark.asyncio
+async def test_conflict(conflict_state):
     a, b, status = conflict_state
 
     with pytest.raises(MetaSyncConflict):
-        metasync(a, b, status, keys=["foo"])
+        await metasync(a, b, status, keys=["foo"])
 
 
-def test_invalid_conflict_resolution(conflict_state):
+@pytest.mark.asyncio
+async def test_invalid_conflict_resolution(conflict_state):
     a, b, status = conflict_state
 
     with pytest.raises(UserError) as excinfo:
-        metasync(a, b, status, keys=["foo"], conflict_resolution="foo")
+        await metasync(a, b, status, keys=["foo"], conflict_resolution="foo")
 
     assert "Invalid conflict resolution setting" in str(excinfo.value)
 
 
-def test_warning_on_custom_conflict_commands(conflict_state, monkeypatch):
+@pytest.mark.asyncio
+async def test_warning_on_custom_conflict_commands(conflict_state, monkeypatch):
     a, b, status = conflict_state
     warnings = []
     monkeypatch.setattr(logger, "warning", warnings.append)
 
     with pytest.raises(MetaSyncConflict):
-        metasync(a, b, status, keys=["foo"], conflict_resolution=lambda *a, **kw: None)
+        await metasync(
+            a,
+            b,
+            status,
+            keys=["foo"],
+            conflict_resolution=lambda *a, **kw: None,
+        )
 
     assert warnings == ["Custom commands don't work on metasync."]
 
 
-def test_conflict_same_content():
+@pytest.mark.asyncio
+async def test_conflict_same_content():
     a = MemoryStorage()
     b = MemoryStorage()
     status = {}
-    a.set_meta("foo", "bar")
-    b.set_meta("foo", "bar")
+    await a.set_meta("foo", "bar")
+    await b.set_meta("foo", "bar")
 
-    metasync(a, b, status, keys=["foo"])
-    assert a.get_meta("foo") == b.get_meta("foo") == status["foo"] == "bar"
+    await metasync(a, b, status, keys=["foo"])
+    assert await a.get_meta("foo") == await b.get_meta("foo") == status["foo"] == "bar"
 
 
 @pytest.mark.parametrize("wins", "ab")
-def test_conflict_x_wins(wins):
+@pytest.mark.asyncio
+async def test_conflict_x_wins(wins):
     a = MemoryStorage()
     b = MemoryStorage()
     status = {}
-    a.set_meta("foo", "bar")
-    b.set_meta("foo", "baz")
+    await a.set_meta("foo", "bar")
+    await b.set_meta("foo", "baz")
 
-    metasync(
+    await metasync(
         a,
         b,
         status,
@@ -119,8 +136,8 @@ def test_conflict_x_wins(wins):
     )
 
     assert (
-        a.get_meta("foo")
-        == b.get_meta("foo")
+        await a.get_meta("foo")
+        == await b.get_meta("foo")
         == status["foo"]
         == ("bar" if wins == "a" else "baz")
     )
@@ -148,7 +165,8 @@ metadata = st.dictionaries(keys, values)
     keys={"0"},
     conflict_resolution="a wins",
 )
-def test_fuzzing(a, b, status, keys, conflict_resolution):
+@pytest.mark.asyncio
+async def test_fuzzing(a, b, status, keys, conflict_resolution):
     def _get_storage(m, instance_name):
         s = MemoryStorage(instance_name=instance_name)
         s.metadata = m
@@ -159,13 +177,13 @@ def test_fuzzing(a, b, status, keys, conflict_resolution):
 
     winning_storage = a if conflict_resolution == "a wins" else b
     expected_values = {
-        key: winning_storage.get_meta(key) for key in keys if key not in status
+        key: await winning_storage.get_meta(key) for key in keys if key not in status
     }
 
-    metasync(a, b, status, keys=keys, conflict_resolution=conflict_resolution)
+    await metasync(a, b, status, keys=keys, conflict_resolution=conflict_resolution)
 
     for key in keys:
         s = status.get(key, "")
-        assert a.get_meta(key) == b.get_meta(key) == s
+        assert await a.get_meta(key) == await b.get_meta(key) == s
         if expected_values.get(key, "") and s:
             assert s == expected_values[key]

--- a/vdirsyncer/cli/__init__.py
+++ b/vdirsyncer/cli/__init__.py
@@ -211,11 +211,9 @@ def discover(ctx, pairs, list):
         conn = aiohttp.TCPConnector(limit_per_host=16)
 
         for pair_name in pairs or config.pairs:
-            pair = config.get_pair(pair_name)
-
             await discover_collections(
                 status_path=config.general["status_path"],
-                pair=pair,
+                pair=config.get_pair(pair_name),
                 from_cache=False,
                 list_collections=list,
                 connector=conn,

--- a/vdirsyncer/cli/__init__.py
+++ b/vdirsyncer/cli/__init__.py
@@ -125,13 +125,16 @@ def sync(ctx, collections, force_delete):
     from .tasks import prepare_pair, sync_collection
 
     for pair_name, collections in collections:
-        prepare_pair(
+        for collection, config in prepare_pair(
             pair_name=pair_name,
             collections=collections,
             config=ctx.config,
-            force_delete=force_delete,
-            callback=sync_collection,
-        )
+        ):
+            sync_collection(
+                collection=collection,
+                general=config,
+                force_delete=force_delete,
+            )
 
 
 @app.command()
@@ -147,12 +150,12 @@ def metasync(ctx, collections):
     from .tasks import prepare_pair, metasync_collection
 
     for pair_name, collections in collections:
-        prepare_pair(
+        for collection, config in prepare_pair(
             pair_name=pair_name,
             collections=collections,
             config=ctx.config,
-            callback=metasync_collection,
-        )
+        ):
+            metasync_collection(collection=collection, general=config)
 
 
 @app.command()

--- a/vdirsyncer/cli/config.py
+++ b/vdirsyncer/cli/config.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import os
 import string
@@ -206,7 +208,7 @@ class Config:
         else:
             return expand_fetch_params(args)
 
-    def get_pair(self, pair_name):
+    def get_pair(self, pair_name: str) -> PairConfig:
         try:
             return self.pairs[pair_name]
         except KeyError as e:

--- a/vdirsyncer/cli/config.py
+++ b/vdirsyncer/cli/config.py
@@ -4,8 +4,6 @@ import string
 from configparser import RawConfigParser
 from itertools import chain
 
-from click_threading import get_ui_worker
-
 from .. import exceptions
 from .. import PROJECT_HOME
 from ..utils import cached_property
@@ -257,11 +255,7 @@ class PairConfig:
                 b_name = self.config_b["instance_name"]
                 command = conflict_resolution[1:]
 
-                def inner():
-                    return _resolve_conflict_via_command(a, b, command, a_name, b_name)
-
-                ui_worker = get_ui_worker()
-                return ui_worker.put(inner)
+                return _resolve_conflict_via_command(a, b, command, a_name, b_name)
 
             return resolve
         else:

--- a/vdirsyncer/cli/tasks.py
+++ b/vdirsyncer/cli/tasks.py
@@ -15,7 +15,7 @@ from .utils import manage_sync_status
 from .utils import save_status
 
 
-def prepare_pair(pair_name, collections, config, callback, **kwargs):
+def prepare_pair(pair_name, collections, config):
     pair = config.get_pair(pair_name)
 
     all_collections = dict(
@@ -34,7 +34,7 @@ def prepare_pair(pair_name, collections, config, callback, **kwargs):
             )
 
         collection = CollectionConfig(pair, collection_name, config_a, config_b)
-        callback(collection=collection, general=config.general, **kwargs)
+        yield collection, config.general
 
 
 def sync_collection(collection, general, force_delete):

--- a/vdirsyncer/metasync.py
+++ b/vdirsyncer/metasync.py
@@ -14,24 +14,24 @@ class MetaSyncConflict(MetaSyncError):
     key = None
 
 
-def metasync(storage_a, storage_b, status, keys, conflict_resolution=None):
-    def _a_to_b():
+async def metasync(storage_a, storage_b, status, keys, conflict_resolution=None):
+    async def _a_to_b():
         logger.info(f"Copying {key} to {storage_b}")
-        storage_b.set_meta(key, a)
+        await storage_b.set_meta(key, a)
         status[key] = a
 
-    def _b_to_a():
+    async def _b_to_a():
         logger.info(f"Copying {key} to {storage_a}")
-        storage_a.set_meta(key, b)
+        await storage_a.set_meta(key, b)
         status[key] = b
 
-    def _resolve_conflict():
+    async def _resolve_conflict():
         if a == b:
             status[key] = a
         elif conflict_resolution == "a wins":
-            _a_to_b()
+            await _a_to_b()
         elif conflict_resolution == "b wins":
-            _b_to_a()
+            await _b_to_a()
         else:
             if callable(conflict_resolution):
                 logger.warning("Custom commands don't work on metasync.")
@@ -40,8 +40,8 @@ def metasync(storage_a, storage_b, status, keys, conflict_resolution=None):
             raise MetaSyncConflict(key)
 
     for key in keys:
-        a = storage_a.get_meta(key)
-        b = storage_b.get_meta(key)
+        a = await storage_a.get_meta(key)
+        b = await storage_b.get_meta(key)
         s = normalize_meta_value(status.get(key))
         logger.debug(f"Key: {key}")
         logger.debug(f"A: {a}")
@@ -49,11 +49,11 @@ def metasync(storage_a, storage_b, status, keys, conflict_resolution=None):
         logger.debug(f"S: {s}")
 
         if a != s and b != s:
-            _resolve_conflict()
+            await _resolve_conflict()
         elif a != s and b == s:
-            _a_to_b()
+            await _a_to_b()
         elif a == s and b != s:
-            _b_to_a()
+            await _b_to_a()
         else:
             assert a == b
 

--- a/vdirsyncer/storage/dav.py
+++ b/vdirsyncer/storage/dav.py
@@ -411,12 +411,18 @@ class DAVSession:
 
         # XXX: This is a temporary hack to pin-point bad refactoring.
         assert self.connector is not None
-        async with aiohttp.ClientSession(
+        async with self._session as session:
+            return await http.request(method, url, session=session, **more)
+
+    @property
+    def _session(self):
+        """Return a new session for requests."""
+
+        return aiohttp.ClientSession(
             connector=self.connector,
             connector_owner=False,
             # TODO use `raise_for_status=true`, though this needs traces first,
-        ) as session:
-            return await http.request(method, url, session=session, **more)
+        )
 
     def get_default_headers(self):
         return {

--- a/vdirsyncer/storage/filesystem.py
+++ b/vdirsyncer/storage/filesystem.py
@@ -41,7 +41,7 @@ class FilesystemStorage(Storage):
         self.post_hook = post_hook
 
     @classmethod
-    def discover(cls, path, **kwargs):
+    async def discover(cls, path, **kwargs):
         if kwargs.pop("collection", None) is not None:
             raise TypeError("collection argument must not be given.")
         path = expand_path(path)
@@ -67,7 +67,7 @@ class FilesystemStorage(Storage):
         return True
 
     @classmethod
-    def create_collection(cls, collection, **kwargs):
+    async def create_collection(cls, collection, **kwargs):
         kwargs = dict(kwargs)
         path = kwargs["path"]
 
@@ -86,7 +86,7 @@ class FilesystemStorage(Storage):
     def _get_href(self, ident):
         return generate_href(ident) + self.fileext
 
-    def list(self):
+    async def list(self):
         for fname in os.listdir(self.path):
             fpath = os.path.join(self.path, fname)
             if (
@@ -96,7 +96,7 @@ class FilesystemStorage(Storage):
             ):
                 yield fname, get_etag_from_file(fpath)
 
-    def get(self, href):
+    async def get(self, href):
         fpath = self._get_filepath(href)
         try:
             with open(fpath, "rb") as f:
@@ -107,7 +107,7 @@ class FilesystemStorage(Storage):
             else:
                 raise
 
-    def upload(self, item):
+    async def upload(self, item):
         if not isinstance(item.raw, str):
             raise TypeError("item.raw must be a unicode string.")
 
@@ -139,7 +139,7 @@ class FilesystemStorage(Storage):
             else:
                 raise
 
-    def update(self, href, item, etag):
+    async def update(self, href, item, etag):
         fpath = self._get_filepath(href)
         if not os.path.exists(fpath):
             raise exceptions.NotFoundError(item.uid)
@@ -158,7 +158,7 @@ class FilesystemStorage(Storage):
             self._run_post_hook(fpath)
         return etag
 
-    def delete(self, href, etag):
+    async def delete(self, href, etag):
         fpath = self._get_filepath(href)
         if not os.path.isfile(fpath):
             raise exceptions.NotFoundError(href)
@@ -176,7 +176,7 @@ class FilesystemStorage(Storage):
         except OSError as e:
             logger.warning("Error executing external hook: {}".format(str(e)))
 
-    def get_meta(self, key):
+    async def get_meta(self, key):
         fpath = os.path.join(self.path, key)
         try:
             with open(fpath, "rb") as f:
@@ -187,7 +187,7 @@ class FilesystemStorage(Storage):
             else:
                 raise
 
-    def set_meta(self, key, value):
+    async def set_meta(self, key, value):
         value = normalize_meta_value(value)
 
         fpath = os.path.join(self.path, key)

--- a/vdirsyncer/storage/google.py
+++ b/vdirsyncer/storage/google.py
@@ -5,7 +5,6 @@ import urllib.parse as urlparse
 
 import click
 from atomicwrites import atomic_write
-from click_threading import get_ui_worker
 
 from . import base
 from . import dav
@@ -41,8 +40,7 @@ class GoogleSession(dav.DAVSession):
             raise exceptions.UserError("requests-oauthlib not installed")
 
         token_file = expand_path(token_file)
-        ui_worker = get_ui_worker()
-        ui_worker.put(lambda: self._init_token(token_file, client_id, client_secret))
+        return self._init_token(token_file, client_id, client_secret)
 
     def _init_token(self, token_file, client_id, client_secret):
         token = None

--- a/vdirsyncer/storage/google.py
+++ b/vdirsyncer/storage/google.py
@@ -3,6 +3,7 @@ import logging
 import os
 import urllib.parse as urlparse
 
+import aiohttp
 import click
 from atomicwrites import atomic_write
 
@@ -28,13 +29,21 @@ except ImportError:
 
 
 class GoogleSession(dav.DAVSession):
-    def __init__(self, token_file, client_id, client_secret, url=None):
+    def __init__(
+        self,
+        token_file,
+        client_id,
+        client_secret,
+        url=None,
+        connector: aiohttp.BaseConnector = None,
+    ):
         # Required for discovering collections
         if url is not None:
             self.url = url
 
         self.useragent = client_id
         self._settings = {}
+        self.connector = connector
 
         if not have_oauth2:
             raise exceptions.UserError("requests-oauthlib not installed")

--- a/vdirsyncer/storage/memory.py
+++ b/vdirsyncer/storage/memory.py
@@ -28,18 +28,18 @@ class MemoryStorage(Storage):
     def _get_href(self, item):
         return item.ident + self.fileext
 
-    def list(self):
+    async def list(self):
         for href, (etag, _item) in self.items.items():
             yield href, etag
 
-    def get(self, href):
+    async def get(self, href):
         etag, item = self.items[href]
         return item, etag
 
-    def has(self, href):
+    async def has(self, href):
         return href in self.items
 
-    def upload(self, item):
+    async def upload(self, item):
         href = self._get_href(item)
         if href in self.items:
             raise exceptions.AlreadyExistingError(existing_href=href)
@@ -47,7 +47,7 @@ class MemoryStorage(Storage):
         self.items[href] = (etag, item)
         return href, etag
 
-    def update(self, href, item, etag):
+    async def update(self, href, item, etag):
         if href not in self.items:
             raise exceptions.NotFoundError(href)
         actual_etag, _ = self.items[href]
@@ -58,15 +58,15 @@ class MemoryStorage(Storage):
         self.items[href] = (new_etag, item)
         return new_etag
 
-    def delete(self, href, etag):
-        if not self.has(href):
+    async def delete(self, href, etag):
+        if not await self.has(href):
             raise exceptions.NotFoundError(href)
         if etag != self.items[href][0]:
             raise exceptions.WrongEtagError(etag)
         del self.items[href]
 
-    def get_meta(self, key):
+    async def get_meta(self, key):
         return normalize_meta_value(self.metadata.get(key))
 
-    def set_meta(self, key, value):
+    async def set_meta(self, key, value):
         self.metadata[key] = normalize_meta_value(value)

--- a/vdirsyncer/utils.py
+++ b/vdirsyncer/utils.py
@@ -26,22 +26,15 @@ def expand_path(p: str) -> str:
     return p
 
 
-def split_dict(d, f):
+def split_dict(d: dict, f: callable):
     """Puts key into first dict if f(key), otherwise in second dict"""
-    a, b = split_sequence(d.items(), lambda item: f(item[0]))
-    return dict(a), dict(b)
-
-
-def split_sequence(s, f):
-    """Puts item into first list if f(item), else in second list"""
-    a = []
-    b = []
-    for item in s:
-        if f(item):
-            a.append(item)
+    a = {}
+    b = {}
+    for k, v in d.items():
+        if f(k):
+            a[k] = v
         else:
-            b.append(item)
-
+            b[k] = v
     return a, b
 
 


### PR DESCRIPTION
So far, all storage test pass with xandikos (a few more with radicale) with the `dav` storages. Haven't gotten to the `google` storage.

All `system` and `unit` tests pass. Manually experimenting with `sync`, `discover` and `metasync` the basics all seem intact, but this still needs more thorough testing.

Non-dav storages have not really been ported, they just "work with the new async interface", but don't really operate async, so don't really have any performance changes.

For dav storages, preliminary results show that this is much faster than multi-threaded support, but there's still a lot of work to be done to really unlock all the benefits we can get from using `asyncio`. There's some reduction in code complexity by trimming out the threading support too.

I'm not 100% happy about passing a `TCPConnector` around so much, but it makes limiting the maximum amount of connections very easily at a global level.

I'll likely need some special wrapper to limit the amount of open files in a similar way (with a limit and a queue).

### Missing

- [x] `google` storage to `asyncio`. Still need to find a library for aiohttp + oauth.
- [x] `google` storage testing. There's no tests for that, so need to set some up to make sure this still works.
- [ ] `etesync` is still tied to run as a module rather than standalone, and won't work with our dependencies.

### Other changes

- Only `sha256` fingerprints for certificates are not supported. `sha1` and `md5` are insecure and have been dropped.