### PR TITLE
Fix pip downloading all versions of pip on CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,7 @@ release-deb:
 	sh scripts/release-deb.sh ubuntu zesty
 
 install-dev:
+	python -m pip install --only-binary :all: pip==21.1.2 -U
 	pip install --upgrade --upgrade-strategy eager pip setuptools wheel
 	pip install -e .
 	pip install -Ur test-requirements.txt $(TEST_EXTRA_PACKAGES)

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ release-deb:
 	sh scripts/release-deb.sh ubuntu zesty
 
 install-dev:
-	python -m pip install --only-binary :all: pip==21.1.2 -U
+	pip install --upgrade --only-binary :all: pip
 	pip install --upgrade --upgrade-strategy eager pip setuptools wheel
 	pip install -e .
 	pip install -Ur test-requirements.txt $(TEST_EXTRA_PACKAGES)

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ release-deb:
 	sh scripts/release-deb.sh ubuntu zesty
 
 install-dev:
-	pip install -U pip setuptools wheel
+	pip install --upgrade --upgrade-strategy eager pip setuptools wheel
 	pip install -e .
 	pip install -Ur test-requirements.txt $(TEST_EXTRA_PACKAGES)
 	pip install pre-commit


### PR DESCRIPTION
Due to the new resolver, lots of different versions were being
downloaded and filled up /tmp.

Unsure if it's an upstream issue or not, but just be eager for now.