### PR TITLE
Run Fastmail on CI again

### DIFF
--- a/.builds/tests-release.yaml
+++ b/.builds/tests-release.yaml
@@ -10,6 +10,7 @@ sources:
   - https://github.com/pimutils/vdirsyncer
 secrets:
   - a36c8ba3-fba0-4338-b402-6aea0fbe771e
+  - 4d9a6dfe-5c8d-48bd-b864-a2f5d772c536
 environment:
   BUILD: test
   CI: true
@@ -33,6 +34,19 @@ tasks:
       # Non-system python is used for packages:
       export PATH=$PATH:~/.local/bin/
       make -e style
+  - check-secrets: |
+      # Stop here if this is a PR. PRs can't run with the below secrets.
+      [ -f ~/fastmail-secrets ] || complete-build
+  - extra-storages: |
+      set +x
+      source ~/fastmail-secrets
+      set -x
+
+      cd vdirsyncer
+      export PATH=$PATH:~/.local/bin/
+      DAV_SERVER=fastmail pytest tests/storage
+  - check-tag: |
+      # Stop here unless this is a tag.
       git describe --exact-match --tags || complete-build
   - publish: |
       cd vdirsyncer

--- a/tests/storage/servers/fastmail/__init__.py
+++ b/tests/storage/servers/fastmail/__init__.py
@@ -5,11 +5,12 @@ import pytest
 
 class ServerMixin:
     @pytest.fixture
-    def get_storage_args(self, item_type, slow_create_collection, aio_connector):
-        if item_type == "VTODO":
-            # Fastmail has non-standard support for TODOs
-            # See https://github.com/pimutils/vdirsyncer/issues/824
-            pytest.skip("Fastmail has non-standard VTODO support.")
+    def get_storage_args(self, slow_create_collection, aio_connector, request):
+        if "item_type" in request.fixturenames:
+            if request.getfixturevalue("item_type") == "VTODO":
+                # Fastmail has non-standard support for TODOs
+                # See https://github.com/pimutils/vdirsyncer/issues/824
+                pytest.skip("Fastmail has non-standard VTODO support.")
 
         async def inner(collection="test"):
             args = {

--- a/tests/storage/servers/fastmail/__init__.py
+++ b/tests/storage/servers/fastmail/__init__.py
@@ -5,7 +5,7 @@ import pytest
 
 class ServerMixin:
     @pytest.fixture
-    def get_storage_args(self, item_type, slow_create_collection):
+    def get_storage_args(self, item_type, slow_create_collection, aio_connector):
         if item_type == "VTODO":
             # Fastmail has non-standard support for TODOs
             # See https://github.com/pimutils/vdirsyncer/issues/824
@@ -15,6 +15,7 @@ class ServerMixin:
             args = {
                 "username": os.environ["FASTMAIL_USERNAME"],
                 "password": os.environ["FASTMAIL_PASSWORD"],
+                "connector": aio_connector,
             }
 
             if self.storage_class.fileext == ".ics":
@@ -25,7 +26,12 @@ class ServerMixin:
                 raise RuntimeError()
 
             if collection is not None:
-                args = slow_create_collection(self.storage_class, args, collection)
+                args = await slow_create_collection(
+                    self.storage_class,
+                    args,
+                    collection,
+                )
+
             return args
 
         return inner


### PR DESCRIPTION
Run our test suite using Fastmail as a backed as part of CI again.

This was long ago set up for Travis, had broken at some point, and Travis was never fixed. Some tests are still being omitted due to some quirks in Fastmail (see #824).

Since `secrets` for Fastmail are required to run this, these will only run for branches of `pimutils/vdirsyncer`, and not for external PRs.