### PR TITLE
Update link for orage

### DIFF
--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -37,7 +37,7 @@ Further applications, with missing pages:
 
 .. _khal: http://lostpackets.de/khal/
 .. _dayplanner: http://www.day-planner.org/
-.. _Orage: http://www.kolumbus.fi/~w408237/orage/
+.. _Orage: https://gitlab.xfce.org/apps/orage
 .. _rainlendar: http://www.rainlendar.net/
 .. _khard: https://github.com/scheibler/khard/
 .. _contactquery.c: https://github.com/t-8ch/snippets/blob/master/contactquery.c


### PR DESCRIPTION
The previous one is 404, and that domain redirects to some random website.

This seems to be unmaintained though, see the [xfce forums](https://forum.xfce.org/viewtopic.php?id=14898) for more details.