### PR TITLE
Sync pairs asynchronously

### DIFF
--- a/vdirsyncer/cli/__init__.py
+++ b/vdirsyncer/cli/__init__.py
@@ -129,6 +129,7 @@ def sync(ctx, collections, force_delete):
     async def main(collections):
         conn = aiohttp.TCPConnector(limit_per_host=16)
 
+        tasks = []
         for pair_name, collections in collections:
             async for collection, config in prepare_pair(
                 pair_name=pair_name,
@@ -136,13 +137,16 @@ def sync(ctx, collections, force_delete):
                 config=ctx.config,
                 connector=conn,
             ):
-                await sync_collection(
-                    collection=collection,
-                    general=config,
-                    force_delete=force_delete,
-                    connector=conn,
+                tasks.append(
+                    sync_collection(
+                        collection=collection,
+                        general=config,
+                        force_delete=force_delete,
+                        connector=conn,
+                    )
                 )
 
+        await asyncio.gather(*tasks)
         await conn.close()
 
     asyncio.run(main(collections))


### PR DESCRIPTION
Not sure how I missed such an obvious one.

Speeds `sync` up by around 50% on my usual setups.