### PR TITLE
Simplify coverage submission

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,10 +2,3 @@ comment: false
 coverage:
   status:
     patch: false
-    project:
-      unit:
-        flags: unit
-      system:
-        flags: system
-      storage:
-        flags: storage

--- a/Makefile
+++ b/Makefile
@@ -43,10 +43,8 @@ all:
 
 ci-test:
 	curl -s https://codecov.io/bash > $(CODECOV_PATH)
-	$(PYTEST) tests/unit/
-	bash $(CODECOV_PATH) -c -F unit
-	$(PYTEST) tests/system/
-	bash $(CODECOV_PATH) -c -F system
+	$(PYTEST) --cov-append tests/unit/ tests/system/
+	bash $(CODECOV_PATH) -c
 	[ "$(ETESYNC_TESTS)" = "false" ] || make test-storage
 
 ci-test-storage:
@@ -55,7 +53,7 @@ ci-test-storage:
 	for server in $(DAV_SERVER); do \
 		DAV_SERVER=$$server $(PYTEST) --cov-append tests/storage; \
 	done
-	bash $(CODECOV_PATH) -c -F storage
+	bash $(CODECOV_PATH) -c
 
 test:
 	$(PYTEST)


### PR DESCRIPTION
We submit separate coverage reports for each group of tests, but codecov
doesn't give us proper tooling to analyse each one separately. When
there's a percentage drop in one, there's no way to pinpoint where -- at
least not without running locally and inspecting results separately.

Treat all coverage as one. Analysis of coverage for each group of tests
can be done offline and manually, but there's little value in keeping it
in codecov.

Should also help us transition a more simplified CI design (e.g.:
running all tests together rather than in groups).