### PR TITLE
Fix issues normalising some characters in UIDs

### DIFF
--- a/vdirsyncer/storage/dav.py
+++ b/vdirsyncer/storage/dav.py
@@ -64,29 +64,11 @@ async def _assert_multistatus_success(r):
 def _normalize_href(base, href):
     """Normalize the href to be a path only relative to hostname and
     schema."""
-    orig_href = href
     if not href:
         raise ValueError(href)
 
     x = urlparse.urljoin(base, href)
     x = urlparse.urlsplit(x).path
-
-    # Encoding issues:
-    # - https://github.com/owncloud/contacts/issues/581
-    # - https://github.com/Kozea/Radicale/issues/298
-    old_x = None
-    while old_x is None or x != old_x:
-        if _contains_quoted_reserved_chars(x):
-            break
-        old_x = x
-        x = urlparse.unquote(x)
-
-    x = urlparse.quote(x, "/@%:")
-
-    if orig_href == x:
-        dav_logger.debug(f"Already normalized: {x!r}")
-    else:
-        dav_logger.debug("Normalized URL from {!r} to {!r}".format(orig_href, x))
 
     return x
 


### PR DESCRIPTION
I'd been looking at this normalisation and had the impression that some handling of safe/unsafe wasn't 100% accurate.

Apparently it's been unnecessary for a while.

Fixes #918