### PR TITLE
Run tests CI python 3.7

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,6 @@
+python37:
+  image: python:3.7
+  before_script:
+    - make -e install-dev
+  script:
+    - make -e ci-test

--- a/vdirsyncer/http.py
+++ b/vdirsyncer/http.py
@@ -140,8 +140,8 @@ async def request(
 
     kwargs.pop("cert", None)  # TODO XXX FIXME!
 
-    # Hacks to translate API
-    if auth := kwargs.pop("auth", None):
+    auth = kwargs.pop("auth", None)
+    if auth:
         kwargs["auth"] = aiohttp.BasicAuth(*auth)
 
     r = func(method, url, ssl=ssl, **kwargs)


### PR DESCRIPTION
Still supporting it, so best to have running tests to make sure we don't break it (again).

Run these on a synthetic (dockerised) environment, since no distribution seems to currently ship this version.