### PR TITLE
Minor simplitication with http response decoding

### DIFF
--- a/vdirsyncer/http.py
+++ b/vdirsyncer/http.py
@@ -159,7 +159,7 @@ async def request(
 
     logger.debug(r.status)
     logger.debug(r.headers)
-    logger.debug(r.content)
+    logger.debug(r.text)
 
     if r.status == 412:
         raise exceptions.PreconditionFailed(r.reason)

--- a/vdirsyncer/storage/dav.py
+++ b/vdirsyncer/storage/dav.py
@@ -546,9 +546,7 @@ class DAVStorage(Storage):
             response = await self.session.request(
                 "REPORT", "", data=data, headers=self.session.get_default_headers()
             )
-            root = _parse_xml(
-                await response.content.read()
-            )  # etree only can handle bytes
+            root = _parse_xml(await response.content.read())
             rv = []
             hrefs_left = set(hrefs)
             for href, etag, prop in self._parse_prop_responses(root):

--- a/vdirsyncer/storage/http.py
+++ b/vdirsyncer/storage/http.py
@@ -74,7 +74,7 @@ class HttpStorage(Storage):
             )
         self._items = {}
 
-        for item in split_collection((await r.read()).decode("utf-8")):
+        for item in split_collection(await r.text()):
             item = Item(item)
             if self._ignore_uids:
                 item = item.with_uid(item.hash)


### PR DESCRIPTION
This should also make sure we always use the right encoding, rather than forcing UTF-8.