### PR TITLE
Add shell strategy to fetch params

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -6,6 +6,7 @@ In alphabetical order:
 - Ben Boeckel
 - Christian Geier
 - Clément Mondon
+- Corey Hinshaw
 - Hugo Osvaldo Barrera
 - Julian Mehne
 - Malte Kiefer

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ may want to subscribe to `GitHub's tag feed
 Version 0.19.0
 ==============
 
+- Add "shell" password fetch strategy to pass command string to a shell.
 - Add "description" and "order" as metadata.  These fetch the CalDAV:
   calendar-description, CardDAV:addressbook-description and apple-ns:calendar-order
   properties.

--- a/docs/keyring.rst
+++ b/docs/keyring.rst
@@ -38,6 +38,12 @@ You can fetch the username as well::
 
 Or really any kind of parameter in a storage section.
 
+You can also pass the command as a string to be executed in a shell::
+
+    [storage foo]
+    ...
+    password.fetch = ["shell", "~/.local/bin/get-my-password | head -n1"]
+
 With pass_ for example, you might find yourself writing something like this in
 your configuration file::
 

--- a/tests/system/cli/test_fetchparams.py
+++ b/tests/system/cli/test_fetchparams.py
@@ -11,7 +11,7 @@ def test_get_password_from_command(tmpdir, runner):
         collections = ["a", "b", "c"]
 
         [storage foo]
-        type = "filesystem"
+        type.fetch = ["shell", "echo filesystem"]
         path = "{base}/foo/"
         fileext.fetch = ["command", "echo", ".txt"]
 

--- a/vdirsyncer/cli/fetchparams.py
+++ b/vdirsyncer/cli/fetchparams.py
@@ -82,7 +82,9 @@ def _strategy_command(*command: str, shell: bool = False):
     expanded_command = list(map(expand_path, command))
 
     try:
-        stdout = subprocess.check_output(expanded_command, universal_newlines=True, shell=shell)
+        stdout = subprocess.check_output(
+            expanded_command, universal_newlines=True, shell=shell
+        )
         return stdout.strip("\n")
     except OSError as e:
         cmd = " ".join(expanded_command)

--- a/vdirsyncer/cli/fetchparams.py
+++ b/vdirsyncer/cli/fetchparams.py
@@ -72,7 +72,7 @@ def _fetch_value(opts, key):
         return rv
 
 
-def _strategy_command(*command: str):
+def _strategy_command(*command: str, shell: bool = False):
     """Execute a user-specified command and return its output."""
     import subprocess
 
@@ -82,11 +82,16 @@ def _strategy_command(*command: str):
     expanded_command = list(map(expand_path, command))
 
     try:
-        stdout = subprocess.check_output(expanded_command, universal_newlines=True)
+        stdout = subprocess.check_output(expanded_command, universal_newlines=True, shell=shell)
         return stdout.strip("\n")
     except OSError as e:
         cmd = " ".join(expanded_command)
         raise exceptions.UserError(f"Failed to execute command: {cmd}\n{str(e)}")
+
+
+def _strategy_shell(*command: str):
+    """Execute a user-specified command string in a shell and return its output."""
+    return _strategy_command(*command, shell=True)
 
 
 def _strategy_prompt(text):
@@ -95,5 +100,6 @@ def _strategy_prompt(text):
 
 STRATEGIES = {
     "command": _strategy_command,
+    "shell": _strategy_shell,
     "prompt": _strategy_prompt,
 }


### PR DESCRIPTION
Adds a new strategy, `shell`, to config fetch parameters. The syntax is nearly identical to the `command` strategy, except that the arguments are run using the `shell=True` subprocess option.

The rationale for this addition is that the output of some password managers (including `pass`) may require piping through additional commands. For example if a `pass` password file is structured as suggested in the documentation:

```
my-secret-password
URL: www.example.com
Username: myuser
```

Then to retrieve only the password, we need to filter the output, for example: `pass my-password | head -n1`

This could be handled on the user side by creating wrapper scripts, but those complicate the use of `vdirsyncer`. Many other tools commonly used in this space (isync, mutt, msmtp, etc.) support password command in shell syntax, so this would remove the need to create custom config scripts for `vdirsyncer`.