### PR TITLE
Corrected installation steps for Ubuntu and pip

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -49,7 +49,7 @@ following things are installed:
 On Linux systems, using the distro's package manager is the best
 way to do this, for example, using Ubuntu::
 
-    sudo apt-get install libxml2 libxslt1.1 zlib1g python
+    sudo apt-get install libxml2 libxslt1.1 zlib1g python3
 
 Then you have several options. The following text applies for most Python
 software by the way.
@@ -59,9 +59,8 @@ The dirty, easy way
 
 The easiest way to install vdirsyncer at this point would be to run::
 
-    pip install --user --ignore-installed vdirsyncer
+    pip install --ignore-installed vdirsyncer
 
-- ``--user`` is to install without root rights (into your home directory)
 - ``--ignore-installed`` is to work around Debian's potentially broken packages
   (see :ref:`debian-urllib3`).
 


### PR DESCRIPTION
I corrected the python source package for Ubuntu to be `python3`, and removed the pip `--user` option, since this is the default now: 

```
# After installing vdirsyncer without --user option 
$ pip list -v | grep "vdirsyncer"
vdirsyncer              0.19.0               /home/USER/.local/lib/python3.8/site-packages pip 
```