### PR TITLE
Enable environment variables for HTTP proxy

### DIFF
--- a/vdirsyncer/storage/dav.py
+++ b/vdirsyncer/storage/dav.py
@@ -422,6 +422,7 @@ class DAVSession:
         return aiohttp.ClientSession(
             connector=self.connector,
             connector_owner=False,
+            trust_env=True,
             # TODO use `raise_for_status=true`, though this needs traces first,
         )
 

--- a/vdirsyncer/storage/http.py
+++ b/vdirsyncer/storage/http.py
@@ -68,6 +68,7 @@ class HttpStorage(Storage):
         async with aiohttp.ClientSession(
             connector=self.connector,
             connector_owner=False,
+            trust_env=True,
             # TODO use `raise_for_status=true`, though this needs traces first,
         ) as session:
             r = await request(


### PR DESCRIPTION
I don't know why it wasn't enabled, but here it is.