### PR TITLE
Allow sync from singlefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ docs/_build/
 vdirsyncer/version.py
 .hypothesis
 coverage.xml
+
+.vscode
+.env

--- a/vdirsyncer/storage/singlefile.py
+++ b/vdirsyncer/storage/singlefile.py
@@ -7,6 +7,7 @@ import os
 from typing import Iterable
 
 from atomicwrites import atomic_write
+from pathlib import Path    
 
 from .. import exceptions
 from ..utils import checkfile
@@ -61,28 +62,14 @@ class SingleFileStorage(Storage):
         if kwargs.pop("collection", None) is not None:
             raise TypeError("collection argument must not be given.")
 
-        path = os.path.abspath(expand_path(path))
-        try:
-            path_glob = path % "*"
-        except TypeError:
-            # If not exactly one '%s' is present, we cannot discover
-            # collections because we wouldn't know which name to assign.
-            raise NotImplementedError
+        args = dict(kwargs)
 
-        placeholder_pos = path.index("%s")
+        # By convention the collection name of a unified .vcf file will the 
+        #   file's stem (name of the file without extension)
+        args["collection"] = Path(path).stem
+        args["path"] = os.path.abspath(expand_path(path))
 
-        for subpath in glob.iglob(path_glob):
-            if os.path.isfile(subpath):
-                args = dict(kwargs)
-                args["path"] = subpath
-
-                collection_end = (
-                    placeholder_pos + 2 + len(subpath) - len(path)  # length of '%s'
-                )
-                collection = subpath[placeholder_pos:collection_end]
-                args["collection"] = collection
-
-                yield args
+        yield args
 
     @classmethod
     async def create_collection(cls, collection, **kwargs):


### PR DESCRIPTION
Fixes #1056

* Created the convention for the `singlefile` to always use the file stem (the filename without extension) as the name of the collection.
* Added `.vscode` and `.env` to `.gitignore`