### PR TITLE
ci: use virtualenvs for jobs that use pip

### DIFF
--- a/.builds/tests-minimal.yml
+++ b/.builds/tests-minimal.yml
@@ -18,6 +18,9 @@ environment:
   REQUIREMENTS: minimal
   # TODO: ETESYNC_TESTS
 tasks:
+  - venv: |
+      python -m venv $HOME/venv
+      echo "export PATH=$HOME/venv/bin:$PATH" >> $HOME/.buildenv
   - setup: |
       sudo systemctl start docker
       cd vdirsyncer

--- a/.builds/tests-pypi.yml
+++ b/.builds/tests-pypi.yml
@@ -17,6 +17,9 @@ environment:
   REQUIREMENTS: release
   # TODO: ETESYNC_TESTS
 tasks:
+  - venv: |
+      python -m venv $HOME/venv
+      echo "export PATH=$HOME/venv/bin:$PATH" >> $HOME/.buildenv
   - setup: |
       sudo systemctl start docker
       cd vdirsyncer


### PR DESCRIPTION
Pip now refuses to tamper with the system python installation.