### PR TITLE
Fix `HealthCheck.all()` deprecation warnings

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,7 +42,7 @@ settings.register_profile(
     "deterministic",
     settings(
         derandomize=True,
-        suppress_health_check=HealthCheck.all(),
+        suppress_health_check=list(HealthCheck),
     ),
 )
 settings.register_profile("dev", settings(suppress_health_check=[HealthCheck.too_slow]))

--- a/tests/unit/test_repair.py
+++ b/tests/unit/test_repair.py
@@ -15,7 +15,7 @@ from vdirsyncer.vobject import Item
 
 @given(uid=uid_strategy)
 # Using the random module for UIDs:
-@settings(suppress_health_check=HealthCheck.all())
+@settings(suppress_health_check=list(HealthCheck))
 @pytest.mark.asyncio
 async def test_repair_uids(uid):
     s = MemoryStorage()
@@ -38,7 +38,7 @@ async def test_repair_uids(uid):
 
 @given(uid=uid_strategy.filter(lambda x: not href_safe(x)))
 # Using the random module for UIDs:
-@settings(suppress_health_check=HealthCheck.all())
+@settings(suppress_health_check=list(HealthCheck))
 @pytest.mark.asyncio
 async def test_repair_unsafe_uids(uid):
     s = MemoryStorage()


### PR DESCRIPTION
When I was running `pytest` there were some deprecation warnings related to `HealthCheck.all()` that should be replaced with `list(HealthCheck)`, so here's the fix. :smile: 