### PR TITLE
fix pylint W0621: Redefining name 'main' from outer scope (line 68) (redefined-outer-name)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
     include_package_data=True,
     cmdclass={"minimal_requirements": PrintRequirements},
     use_scm_version={"write_to": "vdirsyncer/version.py"},
-    entry_points={"console_scripts": ["vdirsyncer = vdirsyncer.cli:main"]},
+    entry_points={"console_scripts": ["vdirsyncer = vdirsyncer.cli:app"]},
     classifiers=[
         "Development Status :: 4 - Beta",
         "Environment :: Console",

--- a/vdirsyncer/cli/__init__.py
+++ b/vdirsyncer/cli/__init__.py
@@ -65,9 +65,6 @@ def app(ctx, config: str):
         ctx.config = load_config(config)
 
 
-main = app
-
-
 def collections_arg_callback(ctx, param, value):
     """
     Expand the various CLI shortforms ("pair, pair/collection") to an iterable


### PR DESCRIPTION
This fixes pylint W0621: Redefining name 'main' from outer scope (line 68) (redefined-outer-name)