### PR TITLE
don't normalize paths in expand_path

### DIFF
--- a/vdirsyncer/utils.py
+++ b/vdirsyncer/utils.py
@@ -20,9 +20,9 @@ _missing = object()
 
 
 def expand_path(p: str) -> str:
-    """Expand $HOME in a path and normalise slashes."""
+    """Expand $HOME/~(user) and environment variables in a path."""
     p = os.path.expanduser(p)
-    p = os.path.normpath(p)
+    p = os.path.expandvars(p)
     return p
 
 


### PR DESCRIPTION
Remove normalizing paths in "expand_path" and expand environment variables. Paths don't need to be normalized, but doing this on non-path parameters (i.e. URLs) might cause bugs.

Reported-by: s-hamann
Closes: https://github.com/pimutils/vdirsyncer/issues/1021