### PR TITLE
storage/http: expose `ignore_uids` config parameter

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -8,6 +8,7 @@ In alphabetical order:
 - Christian Geier
 - Clément Mondon
 - Corey Hinshaw
+- Euxane TRAN-GIRARD
 - Kai Herlemann
 - Hugo Osvaldo Barrera
 - Jason Cox

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ Version 0.19.3
 - Require matching ``BEGIN`` and ``END`` lines in vobjects. :gh:`1103`
 - A Docker environment for Vdirsyncer has been added `Vdirsyncer DOCKERIZED <https://github.com/Bleala/Vdirsyncer-DOCKERIZED>`_.
 - Implement digest auth. :gh:`1137`
+- Expose ``ignore_uids`` config parameter for :storage:`http`, :gh:`1135`
 
 Version 0.19.2
 ==============

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -484,14 +484,7 @@ leads to an error.
         [storage holidays_remote]
         type = "http"
         url = https://example.com/holidays_from_hicksville.ics
-
-    Too many WebCAL providers generate UIDs of all ``VEVENT``-components
-    on-the-fly, i.e. all UIDs change every time the calendar is downloaded.
-    This leads many synchronization programs to believe that all events have
-    been deleted and new ones created, and accordingly causes a lot of
-    unnecessary uploads and deletions on the other side. Vdirsyncer completely
-    ignores UIDs coming from :storage:`http` and will replace them with a hash
-    of the normalized item content.
+        #ignore_uids = true
 
     :param url: URL to the ``.ics`` file.
     :param username: Username for authentication.
@@ -508,3 +501,11 @@ leads to an error.
     :param auth_cert: Optional. Either a path to a certificate with a client
         certificate and the key or a list of paths to the files with them.
     :param useragent: Default ``vdirsyncer``.
+    :param ignore_uids: Ignore UIDs coming from :storage:`http` and replace
+        them with a hash of the normalized item content.
+        Too many WebCAL providers generate UIDs of all ``VEVENT``-components
+        on-the-fly, i.e. all UIDs change every time the calendar is downloaded.
+        This leads many synchronization programs to believe that all events
+        have been deleted and new ones created, and accordingly causes a lot of
+        unnecessary uploads and deletions on the other side.
+        Default: ``true``.

--- a/tests/storage/test_http_with_singlefile.py
+++ b/tests/storage/test_http_with_singlefile.py
@@ -26,8 +26,11 @@ class CombinedStorage(Storage):
         super().__init__(**kwargs)
         self.url = url
         self.path = path
-        self._reader = vdirsyncer.storage.http.HttpStorage(url=url, connector=connector)
-        self._reader._ignore_uids = False
+        self._reader = vdirsyncer.storage.http.HttpStorage(
+            url=url,
+            connector=connector,
+            ignore_uids=False,
+        )
         self._writer = SingleFileStorage(path=path)
 
     async def list(self, *a, **kw):

--- a/vdirsyncer/storage/http.py
+++ b/vdirsyncer/storage/http.py
@@ -32,6 +32,7 @@ class HttpStorage(Storage):
         verify=None,
         auth=None,
         useragent=USERAGENT,
+        ignore_uids=True,
         verify_fingerprint=None,
         auth_cert=None,
         *,
@@ -54,6 +55,7 @@ class HttpStorage(Storage):
 
         self.username, self.password = username, password
         self.useragent = useragent
+        self._ignore_uids = ignore_uids
         assert connector is not None
         self.connector = connector
 


### PR DESCRIPTION
This allows users to choose whether or not to ignore the UIDs coming
from WebCAL providers and instead use the item's content hash. This
remains the default behaviour.

In my case, my provider was generating stable UIDs but was patching the
export date in other fields, resulting in the hash of all events
changing at each synchronisation, having the opposite effect.
