### PR TITLE
Implement digest auth

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,9 +16,6 @@ requirements = [
     "click>=5.0,<9.0",
     "click-log>=0.3.0, <0.5.0",
     "requests >=2.20.0",
-    # https://github.com/sigmavirus24/requests-toolbelt/pull/28
-    # And https://github.com/sigmavirus24/requests-toolbelt/issues/54
-    "requests_toolbelt >=0.4.0",
     # https://github.com/untitaker/python-atomicwrites/commit/4d12f23227b6a944ab1d99c507a69fdbc7c9ed6d  # noqa
     "atomicwrites>=0.1.7",
     "aiohttp>=3.8.0,<4.0.0",

--- a/tests/storage/test_http.py
+++ b/tests/storage/test_http.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import pytest
-from aiohttp import BasicAuth
 from aioresponses import CallbackResult
 from aioresponses import aioresponses
 
 from tests import normalize_item
 from vdirsyncer.exceptions import UserError
+from vdirsyncer.http import BasicAuthMethod, DigestAuthMethod
 from vdirsyncer.storage.http import HttpStorage
 from vdirsyncer.storage.http import prepare_auth
 
@@ -91,16 +91,14 @@ def test_readonly_param(aio_connector):
 def test_prepare_auth():
     assert prepare_auth(None, "", "") is None
 
-    assert prepare_auth(None, "user", "pwd") == BasicAuth("user", "pwd")
-    assert prepare_auth("basic", "user", "pwd") == BasicAuth("user", "pwd")
+    assert prepare_auth(None, "user", "pwd") == BasicAuthMethod("user", "pwd")
+    assert prepare_auth("basic", "user", "pwd") == BasicAuthMethod("user", "pwd")
 
     with pytest.raises(ValueError) as excinfo:
         assert prepare_auth("basic", "", "pwd")
     assert "you need to specify username and password" in str(excinfo.value).lower()
 
-    from requests.auth import HTTPDigestAuth
-
-    assert isinstance(prepare_auth("digest", "user", "pwd"), HTTPDigestAuth)
+    assert isinstance(prepare_auth("digest", "user", "pwd"), DigestAuthMethod)
 
     with pytest.raises(ValueError) as excinfo:
         prepare_auth("ladida", "user", "pwd")

--- a/tests/storage/test_http.py
+++ b/tests/storage/test_http.py
@@ -6,7 +6,8 @@ from aioresponses import aioresponses
 
 from tests import normalize_item
 from vdirsyncer.exceptions import UserError
-from vdirsyncer.http import BasicAuthMethod, DigestAuthMethod
+from vdirsyncer.http import BasicAuthMethod
+from vdirsyncer.http import DigestAuthMethod
 from vdirsyncer.storage.http import HttpStorage
 from vdirsyncer.storage.http import prepare_auth
 
@@ -106,20 +107,12 @@ def test_prepare_auth():
     assert "unknown authentication method" in str(excinfo.value).lower()
 
 
-def test_prepare_auth_guess(monkeypatch):
-    import requests_toolbelt.auth.guess
-
-    assert isinstance(
-        prepare_auth("guess", "user", "pwd"),
-        requests_toolbelt.auth.guess.GuessAuth,
-    )
-
-    monkeypatch.delattr(requests_toolbelt.auth.guess, "GuessAuth")
-
+def test_prepare_auth_guess():
+    # guess auth is currently not supported
     with pytest.raises(UserError) as excinfo:
-        prepare_auth("guess", "user", "pwd")
+        prepare_auth("guess", "usr", "pwd")
 
-    assert "requests_toolbelt is too old" in str(excinfo.value).lower()
+    assert "not supported" in str(excinfo.value).lower()
 
 
 def test_verify_false_disallowed(aio_connector):

--- a/vdirsyncer/http.py
+++ b/vdirsyncer/http.py
@@ -10,35 +10,12 @@ import aiohttp
 import requests.auth
 from requests.utils import parse_dict_header
 
-from . import DOCS_HOME
 from . import __version__
 from . import exceptions
 from .utils import expand_path
 
 logger = logging.getLogger(__name__)
 USERAGENT = f"vdirsyncer/{__version__}"
-
-
-def _detect_faulty_requests():  # pragma: no cover
-    text = (
-        "Error during import: {e}\n\n"
-        "If you have installed vdirsyncer from a distro package, please file "
-        "a bug against that package, not vdirsyncer.\n\n"
-        "Consult {d}/problems.html#requests-related-importerrors"
-        "-based-distributions on how to work around this."
-    )
-
-    try:
-        from requests_toolbelt.auth.guess import GuessAuth  # noqa
-    except ImportError as e:
-        import sys
-
-        print(text.format(e=str(e), d=DOCS_HOME), file=sys.stderr)
-        sys.exit(1)
-
-
-_detect_faulty_requests()
-del _detect_faulty_requests
 
 
 class AuthMethod(ABC):


### PR DESCRIPTION
This PR makes the following changes:

- Re-implements digest auth by wrapping requests's `HTTPDigestAuth` and using it with aiohttp;
- Removes `requests_toolbelt` since it is no longer used;
- Shows a helpful (critial) error for `guess` auth to indicate that it is not supported;
- Updates the test for geuss auth to reflect its status.

Things to consider:
- The wrapper accesses an internal instance variable of `HTTPDigestAuth`, so it might be a good idea to pin requests to a specific version.

I can personally confirm that both basic and digest auth appear to work with a local baikal server, but more testing may be needed.
