### PR TITLE
Do not load netrc config files

### DIFF
--- a/vdirsyncer/http.py
+++ b/vdirsyncer/http.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import logging
+import os
+import platform
 import re
 from abc import ABC, abstractmethod
 from base64 import b64encode
@@ -16,6 +18,13 @@ from .utils import expand_path
 
 logger = logging.getLogger(__name__)
 USERAGENT = f"vdirsyncer/{__version__}"
+
+# 'hack' to prevent aiohttp from loading the netrc config,
+# but still allow it to read PROXY_* env vars.
+# Otherwise, if our host is defined in the netrc config,
+# aiohttp will overwrite our Authorization header.
+# https://github.com/pimutils/vdirsyncer/issues/1138
+os.environ["NETRC"] = "NUL" if platform.system() == "Windows" else "/dev/null"
 
 
 class AuthMethod(ABC):


### PR DESCRIPTION
Resolves a regression in v0.19.3 where aiohttp would overwrite the `Authorization` header if a netrc file with the configured host was present.

Should work but needs testing, especially on Windows as I'm not 100% certain the `NUL` trick will work.

Fixes #1138 