### PR TITLE
Avoid unquoting quoted slashes in an href

### DIFF
--- a/vdirsyncer/storage/dav.py
+++ b/vdirsyncer/storage/dav.py
@@ -53,11 +53,7 @@ def _normalize_href(base, href):
 
     x = urlparse.urljoin(base, href)
     x = urlparse.urlsplit(x).path
-
-    # We unquote and quote again, but want to make sure we
-    # keep around the "@" character.
-    x = urlparse.unquote(x)
-    x = urlparse.quote(x, "/@")
+    x = urlparse.quote(x, "%/@")
 
     if orig_href == x:
         dav_logger.debug(f"Already normalized: {x!r}")


### PR DESCRIPTION
The previous behavior would unquote any %-encoded characters in hrefs, including slashes, and then re-encode them, excluding slashes. This caused a fatal error when the href contained quoted slashes. The final href with the originally quoted slashes now unquoted, would not exist and prevent an entire calendar from syncing completely.

It looks to me like the unquote step is only there to avoid re-quoting already quoted characters. In order to avoid leaving quoted slashes unuoted, I have removed the unquote step and added the % symbol to the list of characters to leave unquoted when quoting the href.