### PR TITLE
Fix _Component.__delitem__ with adjacent identical keys

### DIFF
--- a/vdirsyncer/vobject.py
+++ b/vdirsyncer/vobject.py
@@ -329,7 +329,7 @@ class _Component:
                 break
 
             for line in lineiter:
-                if not line.startswith((" ", "\t")):
+                if not line.startswith((" ", "\t", *prefix)):
                     new_lines.append(line)
                     break
 


### PR DESCRIPTION
Hypothesis found the following example:

```
tests/unit/utils/test_vobject.py:335: in add_prop
    assert c[key] == value
E   AssertionError: assert '0' == '1'
E
E     - 1
E     + 0
E   Falsifying example:
E   state = VobjectMachine()
E   unparsed_0 = state.get_unparsed_lines(encoded=False, joined=False)
E   parsed_0 = state.parse(unparsed=unparsed_0)
E   state.add_prop_raw(c=parsed_0, key='0', params=[], value='0')
E   state.add_prop_raw(c=parsed_0, key='0', params=[], value='0')
E   state.add_prop(c=parsed_0, key='0', value='1')
E   state.teardown()
```

After the two `add_prop_raw` calls, `c.props` is `["0;:0", "0;:0", "FOO:YES"]`.  `_Component.__delitem__` then fails to effectively delete the previous key: it deletes the first `"0;:0"` item, but then checks for continuation lines following it and incorrectly keeps the second `"0;:0"` item even though it begins with one of the prefixes it's trying to delete.  Checking for the prefix in the check for continuation lines fixes this.

Fixes: #1149