### PR TITLE
Use environment proxy configuration for Google storage

### DIFF
--- a/vdirsyncer/storage/google.py
+++ b/vdirsyncer/storage/google.py
@@ -98,6 +98,7 @@ class GoogleSession(dav.DAVSession):
             token_updater=self._save_token,
             connector=self.connector,
             connector_owner=False,
+            trust_env=True,
         )
 
     async def _init_token(self):


### PR DESCRIPTION
Hi, 
this is a small fix that ensures proxy settings from the environment variables will be honored in OAuth2Session of Google storage. Previously PR #1031 was done with the goal of supporting environment proxy configuration, but the OAuth2Session was left out and `trust_env=True` was only set for ClientSession.