### PR TITLE
updates `SqliteStatus` to properly close connections

### DIFF
--- a/vdirsyncer/sync/status.py
+++ b/vdirsyncer/sync/status.py
@@ -169,6 +169,14 @@ class SqliteStatus(_StatusBase):
             ); """
             )
 
+    def close(self):
+        if self._c:
+            self._c.close()
+            self._c = None
+
+    def __del__(self):
+        self.close()
+
     def _is_latest_version(self):
         try:
             return bool(


### PR DESCRIPTION
otherwise, when trying to run `pytest` in a `python3.13` environment results in a bunch of

```
tests/unit/sync/test_sync.py::test_partial_sync_ignore
  /home/user/.asdf/installs/python/3.13.1/lib/python3.13/asyncio/base_events.py:650: ResourceWarning: unclosed database in <sqlite3.Connection object at 0x7fda8f6b6c50>
    sys.set_asyncgen_hooks(
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.
  ```