### PR TITLE
Remove references to obsolete event_loop fixture

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ addopts = """
 --color=yes
 """
 # filterwarnings=error
+asyncio_default_fixture_loop_scope = "function"
 
 [tool.mypy]
 ignore_missing_imports = true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,12 +59,12 @@ else:
 
 
 @pytest_asyncio.fixture
-async def aio_session(event_loop):
+async def aio_session():
     async with aiohttp.ClientSession() as session:
         yield session
 
 
 @pytest_asyncio.fixture
-async def aio_connector(event_loop):
+async def aio_connector():
     async with aiohttp.TCPConnector(limit_per_host=16) as conn:
         yield conn


### PR DESCRIPTION
It's gone from the latest pytest-asyncio.