### PR TITLE
Log error response body in debug

### DIFF
--- a/vdirsyncer/http.py
+++ b/vdirsyncer/http.py
@@ -223,6 +223,10 @@ async def request(
     logger.debug(response.headers)
     logger.debug(response.content)
 
+    if logger.getEffectiveLevel() <= logging.DEBUG and response.status >= 400:
+        # https://github.com/pimutils/vdirsyncer/issues/1186
+        logger.debug(await response.text())
+
     if response.status == 412:
         raise exceptions.PreconditionFailed(response.reason)
     if response.status in (404, 410):


### PR DESCRIPTION
See https://github.com/pimutils/vdirsyncer/issues/1186 for a description of the problem. This is a sort of hacky improvement which addresses the usability problem. I don't think it breaks anything, because I realized that seeing the response bodies is most useful when there is an error, and when there is an error, `resp.raise_for_status()` below will throw an exception, so nothing will be able to try reading the already-consumed response body anyway.