### PR TITLE
Remove python-requests-toolbelt from Arch Linux build

### DIFF
--- a/.builds/archlinux-py313.yml
+++ b/.builds/archlinux-py313.yml
@@ -14,7 +14,6 @@ packages:
   - python-click-log
   - python-click-threading
   - python-requests
-  - python-requests-toolbelt
   - python-aiohttp-oauthlib
   # Test dependencies:
   - python-hypothesis


### PR DESCRIPTION
The dependency was dropped in 89a01631facebc2724cace261fa2b6954dff3aa9