### PR TITLE
Drop support for Python 3.9

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@ sphinx:
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.9"
+    python: "3.10"
 
 python:
   install:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@ Version 0.21.0
 
 - Implement retrying for ``google`` storage type when a rate limit is reached.
 - ``tenacity`` is now a required dependency.
-- Drop support for Python 3.8.
+- Drop support for Python 3.8 and 3.9.
 
 Version 0.20.0
 ==============

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -42,7 +42,7 @@ If your distribution doesn't provide a package for vdirsyncer, you still can
 use Python's package manager "pip". First, you'll have to check that the
 following things are installed:
 
-- Python 3.9 to 3.13 and pip.
+- Python 3.10 to 3.13 and pip.
 - ``libxml`` and ``libxslt``
 - ``zlib``
 - Linux or macOS. **Windows is not supported**, see :gh:`535`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 ]
 description = "Synchronize calendars and contacts"
 readme = "README.rst"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 keywords = ["todo", "task", "icalendar", "cli"]
 license = "BSD-3-Clause"
 license-files = ["LICENSE"]
@@ -27,7 +27,6 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
-    "Programming Language :: Python :: 3.9",
     "Topic :: Internet",
     "Topic :: Office/Business :: Scheduling",
     "Topic :: Utilities",

--- a/vdirsyncer/__init__.py
+++ b/vdirsyncer/__init__.py
@@ -23,8 +23,8 @@ __all__ = ["__version__"]
 def _check_python_version():
     import sys
 
-    if sys.version_info < (3, 9, 0):  # noqa: UP036
-        print("vdirsyncer requires at least Python 3.9.")
+    if sys.version_info < (3, 10, 0):  # noqa: UP036
+        print("vdirsyncer requires at least Python 3.10.")
         sys.exit(1)
 
 

--- a/vdirsyncer/storage/google_helpers.py
+++ b/vdirsyncer/storage/google_helpers.py
@@ -7,9 +7,9 @@ from __future__ import annotations
 import logging
 import wsgiref.simple_server
 import wsgiref.util
+from collections.abc import Callable
 from collections.abc import Iterable
 from typing import Any
-from typing import Callable
 
 logger = logging.getLogger(__name__)
 

--- a/vdirsyncer/utils.py
+++ b/vdirsyncer/utils.py
@@ -6,8 +6,8 @@ import os
 import sys
 import tempfile
 import uuid
+from collections.abc import Callable
 from inspect import getfullargspec
-from typing import Callable
 
 from . import exceptions
 


### PR DESCRIPTION
It is not receiving any more security updates as of 2020-10-05, and shall be entirely unsupported upstream.
