### PR TITLE
Fix: fix hard stop when facing 404 resources on the server

### DIFF
--- a/vdirsyncer/storage/dav.py
+++ b/vdirsyncer/storage/dav.py
@@ -550,7 +550,7 @@ class DAVStorage(Storage):
                 else:
                     rv.append((href, Item(raw), etag))
             for href in hrefs_left:
-                raise exceptions.NotFoundError(href)
+                dav_logger.warning(f"Server does not have referenced item: {href}")
 
             for href, item, etag in rv:
                 yield href, item, etag


### PR DESCRIPTION
Everyone's darling Google-Caldav server might reference resources which, in the end, do not exist:

    debug:   <ns0:href>/caldav/v2/user@example.com/events/_60q30c1g60o...@google.com.ics</ns0:href>
    debug:   <ns0:status>HTTP/1.1 404 Not Found</ns0:status>

This situation leads to an unconditional hard stop of processing all the other, valid and available calendar entries:

    error: Unknown error occurred for my_sync/user@example.com: /caldav/v2/user@example.com/events/_60q30c1g60o...@google.com.ics
    error: Use `-vdebug` to see the full traceback.

Instead of a hard stop, this PR changes the behaviour of vdirsyncer to just print a warning and continue.