### PR TITLE
Bump setuptools requirement for PEP 639

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 # how to package vdirsyncer.
 
 [build-system]
-requires = ["setuptools>=64", "setuptools_scm>=8"]
+requires = ["setuptools>=77.0.0", "setuptools_scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
`license` and `license-files` are only supported since `setuptools` 77.0.0, see https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html