### PR TITLE
Handle missing hrefs in DAV multiget

### DIFF
--- a/tests/storage/dav/__init__.py
+++ b/tests/storage/dav/__init__.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import os
+import re
 import uuid
+import xml.etree.ElementTree as ET
 
 import aiohttp
 import aiostream
 import pytest
+from aioresponses import aioresponses
 
 from tests import assert_item_equals
 from tests.storage import StorageTests
@@ -51,3 +54,50 @@ class DAVStorageTests(ServerMixin, StorageTests):
         href, _etag = await s.upload(item)
         item2, _etag2 = await s.get(href)
         assert_item_equals(item, item2)
+
+    @pytest.mark.asyncio
+    async def test_dav_get_multi_missing_href_batch_is_nonfatal(
+        self, s, get_item, monkeypatch
+    ):
+        item = get_item()
+        existing_href, _etag = await s.upload(item)
+        missing_href = existing_href + ".missing"
+
+        def _fake_parse_prop_responses(_root):
+            prop = ET.Element("prop")
+            ET.SubElement(prop, s.get_multi_data_query).text = item.raw
+            return [(existing_href, '"etag-existing"', prop)]
+
+        monkeypatch.setattr(s, "_parse_prop_responses", _fake_parse_prop_responses)
+        url = str(s.url).rstrip("/")
+        url_pattern = re.compile(rf"^{re.escape(url)}/?$")
+        with aioresponses() as m:
+            m.add(url_pattern, method="REPORT", status=207, body="<multistatus/>")
+            result = await aiostream.stream.list(
+                s.get_multi([existing_href, missing_href])
+            )
+        assert len(m.requests) == 1
+        assert len(result) == 1
+        href, returned_item, etag = result[0]
+        assert href == existing_href
+        assert etag == '"etag-existing"'
+        assert_item_equals(item, returned_item)
+
+    @pytest.mark.asyncio
+    async def test_dav_get_multi_missing_single_href_raises(
+        self, s, get_item, monkeypatch
+    ):
+        existing_href, _etag = await s.upload(get_item())
+        href = existing_href + ".missing"
+
+        def _fake_parse_prop_responses(_root):
+            return []
+
+        monkeypatch.setattr(s, "_parse_prop_responses", _fake_parse_prop_responses)
+        url = str(s.url).rstrip("/")
+        url_pattern = re.compile(rf"^{re.escape(url)}/?$")
+        with aioresponses() as m:
+            m.add(url_pattern, method="REPORT", status=207, body="<multistatus/>")
+            with pytest.raises(exceptions.NotFoundError):
+                await aiostream.stream.list(s.get_multi([href]))
+        assert len(m.requests) == 1

--- a/vdirsyncer/storage/dav.py
+++ b/vdirsyncer/storage/dav.py
@@ -549,8 +549,16 @@ class DAVStorage(Storage):
                         dav_logger.warning(f"Server sent unsolicited item: {href}")
                 else:
                     rv.append((href, Item(raw), etag))
-            for href in hrefs_left:
+            if len(hrefs) == 1 and hrefs_left:
+                # Preserve get(href) semantics for single-item lookups.
+                (href,) = hrefs_left
                 raise exceptions.NotFoundError(href)
+
+            # In multiget, tolerate transiently missing hrefs from the server.
+            for href in hrefs_left:
+                dav_logger.warning(
+                    f"Skipping {href}, server did not return the item in REPORT."
+                )
 
             for href, item, etag in rv:
                 yield href, item, etag


### PR DESCRIPTION
## Summary

Fix DAV multiget robustness when a server omits some requested hrefs in `REPORT` responses.

`DAVStorage.get_multi()` currently raises `NotFoundError` if any requested href is missing from the multiget response. In practice, some DAV servers can intermittently advertise an item and then omit it in a subsequent multiget response. This aborts the whole sync batch.

This patch changes behavior to:

- keep strict `NotFoundError` behavior for single-item lookups (`get(href)` semantics unchanged)
- treat missing hrefs in batch multiget as transient:
  - log a warning
  - continue yielding items that were returned

## Why

In real-world sync runs against Google CalDAV, we observed intermittent omissions for one href in a batch multiget, which caused the whole sync to fail even though other items were valid.

The new behavior preserves strictness where callers expect exact lookup semantics (single href), while improving resilience for batch synchronization.

## Changes

- `vdirsyncer/storage/dav.py`
  - In `get_multi()`:
    - if exactly one href was requested and not returned: still raise `NotFoundError`
    - if multiple hrefs were requested: warn and continue for missing hrefs

- `tests/storage/dav/__init__.py`
  - Added test: batch multiget with one missing href is non-fatal and returns available item(s)
  - Added test: single missing href still raises `NotFoundError`
  - Tests mock DAV `REPORT` using `aioresponses` (matches existing DAV test style)

## Reproduction (before)

`vdirsyncer sync` could fail with:

`Unknown error occurred ... NotFoundError(<missing href>)`

even though the server returned other items in the same multiget response.

## Behavior after

- Batch sync no longer aborts when one href is omitted by the server in multiget
- Single href lookups remain strict and still fail with `NotFoundError`

## Notes

- This is intentionally narrow in scope and only affects missing-href handling in DAV multiget.
- No change to authentication, request construction, or item parsing.

## Validation status

- `pytest` (full suite): **418 passed**, 166 skipped, 2 xfailed.
- `DAV_SERVER=radicale pytest tests/storage -q`: **362 passed**, 71 skipped, 1 xpassed.
- `DAV_SERVER=xandikos pytest tests/storage -q`: **369 passed**, 65 skipped.

### Validation commands and output

```bash
source ~/codes/vdirsyncer/.venv/bin/activate
cd ~/codes/vdirsyncer/vdirsyncer

pytest
# 418 passed, 166 skipped, 2 xfailed

DAV_SERVER=radicale pytest tests/storage -q
# 362 passed, 71 skipped, 1 xpassed

DAV_SERVER=xandikos pytest tests/storage -q
# 369 passed, 65 skipped
```

## AI-assisted notice

This contribution was prepared with AI assistance from OpenAI Codex (GPT-5-based coding assistant, model family: GPT-5/Codex).  
All code changes and final content were reviewed and validated by the author before submission.
