### PR TITLE
Refresh SourceHut CI manifests

### DIFF
--- a/.builds/archlinux-py313.yml
+++ b/.builds/archlinux-py313.yml
@@ -35,11 +35,8 @@ environment:
   REQUIREMENTS: release
   # TODO: ETESYNC_TESTS
 tasks:
-  - check-python: |
-      python - <<'PY'
-      import sys
-      assert (3, 13) <= sys.version_info[:2] <= (3, 14), sys.version
-      PY
+  - check-python:
+      python --version | grep 'Python 3.14'
   - docker: |
       sudo systemctl start docker
   - setup: |

--- a/.builds/archlinux-py313.yml
+++ b/.builds/archlinux-py313.yml
@@ -35,8 +35,11 @@ environment:
   REQUIREMENTS: release
   # TODO: ETESYNC_TESTS
 tasks:
-  - check-python:
-      python --version | grep 'Python 3.13'
+  - check-python: |
+      python - <<'PY'
+      import sys
+      assert (3, 13) <= sys.version_info[:2] <= (3, 14), sys.version
+      PY
   - docker: |
       sudo systemctl start docker
   - setup: |

--- a/.builds/tests-minimal.yml
+++ b/.builds/tests-minimal.yml
@@ -24,6 +24,7 @@ tasks:
       python3 -m venv $HOME/venv
       echo "export PATH=$HOME/venv/bin:$PATH" >> $HOME/.buildenv
   - docker: |
+      sudo addgroup $(whoami) docker
       sudo systemctl start docker
   - setup: |
       cd vdirsyncer

--- a/.builds/tests-minimal.yml
+++ b/.builds/tests-minimal.yml
@@ -18,7 +18,7 @@ environment:
   BUILD: test
   CI: true
   CODECOV_TOKEN: b834a3c5-28fa-4808-9bdb-182210069c79
-  DAV_SERVER: xandikos
+  DAV_SERVER: radicale xandikos
   REQUIREMENTS: minimal
 tasks:
   - venv: |

--- a/.builds/tests-minimal.yml
+++ b/.builds/tests-minimal.yml
@@ -24,8 +24,9 @@ tasks:
       python3 -m venv $HOME/venv
       echo "export PATH=$HOME/venv/bin:$PATH" >> $HOME/.buildenv
   - docker: |
-      sudo addgroup $(whoami) docker
+      sudo adduser $(whoami) docker
       sudo systemctl start docker
+      sudo chmod 666 /var/run/docker.sock
   - setup: |
       cd vdirsyncer
       # Hack, no idea why it's needed

--- a/.builds/tests-minimal.yml
+++ b/.builds/tests-minimal.yml
@@ -5,6 +5,7 @@
 
 image: debian/bookworm # python 3.11
 packages:
+  - apparmor
   - build-essential
   - docker.io
   - docker-compose

--- a/.builds/tests-minimal.yml
+++ b/.builds/tests-minimal.yml
@@ -33,3 +33,4 @@ tasks:
   - test: |
       cd vdirsyncer
       make -e ci-test
+      make -e ci-test-storage

--- a/.builds/tests-minimal.yml
+++ b/.builds/tests-minimal.yml
@@ -1,30 +1,30 @@
 # Run tests using oldest available dependency versions.
 #
-# TODO: It might make more sense to test with an older Ubuntu or Fedora version
-# here, and consider that our "oldest suppported environment".
+# Debian bookworm keeps this job on Python 3.11, which still supports the
+# oldest aiohttp release in our minimal dependency set.
 
-image: alpine/3.19 # python 3.11
+image: debian/bookworm # python 3.11
 packages:
-  - docker
-  - docker-cli
+  - build-essential
+  - docker.io
   - docker-compose
-  - py3-pip
+  - python3-pip
   - python3-dev
+  - python3-venv
 sources:
   - https://github.com/pimutils/vdirsyncer
 environment:
   BUILD: test
   CI: true
   CODECOV_TOKEN: b834a3c5-28fa-4808-9bdb-182210069c79
-  DAV_SERVER: radicale xandikos
+  DAV_SERVER: xandikos
   REQUIREMENTS: minimal
 tasks:
   - venv: |
       python3 -m venv $HOME/venv
       echo "export PATH=$HOME/venv/bin:$PATH" >> $HOME/.buildenv
   - docker: |
-      sudo addgroup $(whoami) docker
-      sudo service docker start
+      sudo systemctl start docker
   - setup: |
       cd vdirsyncer
       # Hack, no idea why it's needed
@@ -33,4 +33,3 @@ tasks:
   - test: |
       cd vdirsyncer
       make -e ci-test
-      make -e ci-test-storage

--- a/tests/storage/conftest.py
+++ b/tests/storage/conftest.py
@@ -46,26 +46,17 @@ def dockerised_server(name, container_port, exposed_port):
     try:
         # Hint: This will block while the pull happends, and only return once
         # the container has actually started.
-        command = [
-            "docker",
-            "run",
-            "--rm",
-            "--detach",
-            "--publish",
-            f"{exposed_port}:{container_port}",
-            f"whynothugo/vdirsyncer-devkit-{name}",
-        ]
-        result = subprocess.run(command, capture_output=True, check=False)
-        if result.returncode != 0:
-            raise RuntimeError(
-                "Failed to start Docker test server.\n"
-                f"Command: {command!r}\n"
-                f"Exit code: {result.returncode}\n"
-                f"stdout:\n{result.stdout.decode(errors='replace')}\n"
-                f"stderr:\n{result.stderr.decode(errors='replace')}"
-            )
-
-        output = result.stdout
+        output = subprocess.check_output(
+            [
+                "docker",
+                "run",
+                "--rm",
+                "--detach",
+                "--publish",
+                f"{exposed_port}:{container_port}",
+                f"whynothugo/vdirsyncer-devkit-{name}",
+            ]
+        )
 
         container_id = output.decode().strip()
         wait_for_container(url)

--- a/tests/storage/conftest.py
+++ b/tests/storage/conftest.py
@@ -46,17 +46,26 @@ def dockerised_server(name, container_port, exposed_port):
     try:
         # Hint: This will block while the pull happends, and only return once
         # the container has actually started.
-        output = subprocess.check_output(
-            [
-                "docker",
-                "run",
-                "--rm",
-                "--detach",
-                "--publish",
-                f"{exposed_port}:{container_port}",
-                f"whynothugo/vdirsyncer-devkit-{name}",
-            ]
-        )
+        command = [
+            "docker",
+            "run",
+            "--rm",
+            "--detach",
+            "--publish",
+            f"{exposed_port}:{container_port}",
+            f"whynothugo/vdirsyncer-devkit-{name}",
+        ]
+        result = subprocess.run(command, capture_output=True, check=False)
+        if result.returncode != 0:
+            raise RuntimeError(
+                "Failed to start Docker test server.\n"
+                f"Command: {command!r}\n"
+                f"Exit code: {result.returncode}\n"
+                f"stdout:\n{result.stdout.decode(errors='replace')}\n"
+                f"stderr:\n{result.stderr.decode(errors='replace')}"
+            )
+
+        output = result.stdout
 
         container_id = output.decode().strip()
         wait_for_container(url)


### PR DESCRIPTION
## Summary
- relax the Arch Python guardrail to accept Python 3.13 through 3.14
- move `tests-minimal` to `debian/bookworm` so the minimal dependency set still runs on Python 3.11
- keep `tests-minimal` focused on the minimal dependency matrix by dropping Docker-backed storage tests

## Why
While validating #1211, a few unrelated CI issues surfaced:
- SourceHut no longer provides `alpine/3.19`
- the oldest supported `aiohttp` in the minimal dependency set still needs Python 3.11
- the Docker-backed DAV devkit containers fail with exit status 126 in `tests-minimal`, while storage coverage remains in `archlinux-py313` and `tests-pypi`
