### PR TITLE
Improve error message when status database is locked (#720)

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -18,6 +18,7 @@ In alphabetical order:
 - Michael Adler
 - rEnr3n
 - Thomas Weißschuh
+- Vladimir Babin
 - Witcher01
 - samm81
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,8 @@ Version 0.21.0
 - Drop support for Python 3.8.
 - Retry transient network errors for nullipotent requests.
 - Add support for Python 3.14.
+- Show a helpful error message instead of a traceback when the status database
+  is locked.
 
 Version 0.20.0
 ==============

--- a/tests/system/cli/test_utils.py
+++ b/tests/system/cli/test_utils.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import sqlite3
+
 import pytest
 
 from vdirsyncer import exceptions
@@ -17,6 +19,26 @@ def test_handle_cli_error(capsys):
     _out, err = capsys.readouterr()
     assert "returned something vdirsyncer doesn't understand" in err
     assert "ayy lmao" in err
+
+
+def test_handle_cli_error_database_locked(capsys):
+    try:
+        raise sqlite3.OperationalError("database is locked")
+    except BaseException:
+        handle_cli_error("my_pair/my_collection")
+
+    _out, err = capsys.readouterr()
+    assert "status database is locked" in err
+    assert "my_pair/my_collection" in err
+    assert "Traceback" not in err
+
+
+def test_handle_cli_error_other_operational_error(capsys):
+    with pytest.raises(sqlite3.OperationalError):
+        try:
+            raise sqlite3.OperationalError("no such table: status")
+        except BaseException:
+            handle_cli_error("my_pair/my_collection")
 
 
 @pytest.mark.asyncio

--- a/vdirsyncer/cli/utils.py
+++ b/vdirsyncer/cli/utils.py
@@ -5,6 +5,7 @@ import errno
 import importlib
 import json
 import os
+import sqlite3
 import sys
 from typing import Any
 
@@ -137,6 +138,17 @@ def handle_cli_error(status_name=None, exc=None):
             "One or more storages don't support `collections = null`. "
             'You probably want to set `collections = ["from a", "from b"]`.'
         )
+    except sqlite3.OperationalError as e:
+        if "database is locked" in str(e):
+            cli_logger.error(
+                f"{status_name}: The status database is locked. This usually "
+                "means another vdirsyncer process is running, or a previous run "
+                "was interrupted. Make sure no other vdirsyncer process is "
+                "running, then try again. If the problem persists, delete the "
+                "`.items` file for this collection in your status directory."
+            )
+        else:
+            raise
     except Exception as e:
         tb = sys.exc_info()[2]
         import traceback


### PR DESCRIPTION
Closes #720.

## What

When the sqlite status database is locked (another vdirsyncer process running,
or a previous run interrupted), `vdirsyncer sync` printed a bare "Unknown error
occurred … Use `-vdebug` to see the full traceback." That's what the issue asked
to improve.

## Fix

`handle_cli_error` now catches `sqlite3.OperationalError`. If the message is
`database is locked`, it prints an actionable hint (make sure no other
vdirsyncer process is running; delete the `.items` file for the collection as a
last resort). Any other `OperationalError` is re-raised so it still reaches the
generic handler unchanged.

## Tests

Added to `tests/system/cli/test_utils.py`, mirroring the existing
`test_handle_cli_error`:

- `test_handle_cli_error_database_locked` — asserts the friendly message and no
  traceback.
- `test_handle_cli_error_other_operational_error` — asserts an unrelated
  `OperationalError` is re-raised.

## Validation

```
$ python -m pytest tests/system/cli/test_utils.py -q
4 passed
```

RED→GREEN: with the source fix reverted (tests kept), both new tests fail
(`assert 'status database is locked' in …` fails; `DID NOT RAISE
OperationalError`); with the fix, all pass.

`ruff format --check` clean on both files. Happy to adjust the wording.
